### PR TITLE
Fix build by uncommenting necessary include for "Verification/SymbolicAbstraction/Utils/Z3APIExtension.h"

### DIFF
--- a/lib/Verification/SymbolicAbstraction/Analyzers/Analyzer.cpp
+++ b/lib/Verification/SymbolicAbstraction/Analyzers/Analyzer.cpp
@@ -18,10 +18,10 @@
 #include "Verification/SymbolicAbstraction/Core/repr.h"
 #include "Verification/SymbolicAbstraction/Utils/Config.h"
 #include "Verification/SymbolicAbstraction/Utils/Utils.h"
+#include "Verification/SymbolicAbstraction/Utils/Z3APIExtension.h"
 
 #include <llvm/IR/CFG.h>
 #include <llvm/Support/Timer.h>
-// #include "Verification/SymbolicAbstraction/Utils/Z3APIExtension.h"
 
 namespace symbolic_abstraction {
 Analyzer::Analyzer(const FunctionContext &fctx, const FragmentDecomposition &fd,

--- a/lib/Verification/SymbolicAbstraction/Core/FunctionContext.cpp
+++ b/lib/Verification/SymbolicAbstraction/Core/FunctionContext.cpp
@@ -16,7 +16,7 @@
 #include "Verification/SymbolicAbstraction/Core/ValueMapping.h"
 // #include "Verification/SymbolicAbstraction/Core/repr.h"
 #include "Verification/SymbolicAbstraction/Utils/Config.h"
-// #include "Verification/SymbolicAbstraction/Utils/Z3APIExtension.h"
+#include "Verification/SymbolicAbstraction/Utils/Z3APIExtension.h"
 
 #include <algorithm>
 #include <queue>


### PR DESCRIPTION
Fix build by uncommenting necessary include for "Verification/SymbolicAbstraction/Utils/Z3APIExtension.h"