### PR TITLE
apa: EAN equality-saturation optimizer&TranslAPA baseline

### DIFF
--- a/include/Dataflow/APA/Analyses/Inter/Reachability.h
+++ b/include/Dataflow/APA/Analyses/Inter/Reachability.h
@@ -23,6 +23,13 @@ InterReachableResult runInterSummaryElimReachable(
     llvm::Function *Entry, const dataflow::controlflow::InterCFG *ICF = nullptr,
     PathSummaryEquationOptions Options = {});
 
+// Modular (E6) variant: builds per-procedure summaries and interprets them with
+// a context-insensitive (functional) fixpoint. Opt-in alternative to the
+// whole-program ForwardInterSummarySolver above.
+InterReachableResult runModularInterReachable(
+    llvm::Function *Entry, const dataflow::controlflow::InterCFG *ICF = nullptr,
+    PathSummaryEquationOptions Options = {});
+
 } // namespace elimination
 
 #endif // DATAFLOW_APA_CLIENTS_LLVM_INTER_REACHABILITY_H_

--- a/include/Dataflow/APA/Analyses/Intra/IntraAffineEqualities.h
+++ b/include/Dataflow/APA/Analyses/Intra/IntraAffineEqualities.h
@@ -1,0 +1,29 @@
+#ifndef DATAFLOW_APA_CLIENTS_LLVM_INTRA_AFFINE_EQUALITIES_H_
+#define DATAFLOW_APA_CLIENTS_LLVM_INTRA_AFFINE_EQUALITIES_H_
+
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instruction.h"
+
+#include "Dataflow/APA/APA.h"
+#include "Dataflow/APA/LLVM/ForwardProblem.h"
+#include "Dataflow/APA/Domains/AffineRelationDomain.h"
+
+namespace elimination {
+
+// Intraprocedural affine-relation (affine-equalities) analysis on the
+// path-expression elimination solver. The fact is an AffineRelation over the
+// function's tracked scalar vocabulary; the path-expression interpreter maps
+// Union -> combine (affine hull / join), Concat -> extend (relational
+// composition), Star -> fixpoint iteration (converges finitely in Howell normal
+// form). Because the affine transformer distributes over the join, the full
+// Kleene EAN law profile is sound for this client (unlike reachability /
+// liveness), making it the paper's positive R1 (law-gated admissibility) case.
+using AffineFact = AffineRelationDomain::value_type;
+using AffineResult =
+    DataFlowResultT<llvm::Instruction *, AffineFact, llvm::Instruction *>;
+
+AffineResult runIntraElimAffine(llvm::Function *F, EliminationOptions Opts = {});
+
+} // namespace elimination
+
+#endif // DATAFLOW_APA_CLIENTS_LLVM_INTRA_AFFINE_EQUALITIES_H_

--- a/include/Dataflow/APA/Analyses/Intra/Reachability.h
+++ b/include/Dataflow/APA/Analyses/Intra/Reachability.h
@@ -16,6 +16,13 @@ using ReachableResult =
 ReachableResult runIntraElimReachable(llvm::Function *F,
                                       EliminationOptions Opts = {});
 
+// TranslAPA baseline variant: interpret the path-expression DAG with the
+// closed-form Gen/Kill semiring. Reachability is the degenerate one-fact
+// lattice (identity transfer), so this is mainly a wiring/timing smoke path;
+// the fold time is recorded in SolveDiagnostics::interp_time_us.
+ReachableResult runIntraTranslApaReachable(llvm::Function *F,
+                                           EliminationOptions Opts = {});
+
 } // namespace elimination
 
 #endif // DATAFLOW_APA_CLIENTS_LLVM_INTRA_REACHABILITY_H_

--- a/include/Dataflow/APA/Analyses/Intra/ReachingDefinitions.h
+++ b/include/Dataflow/APA/Analyses/Intra/ReachingDefinitions.h
@@ -29,6 +29,16 @@ runIntraElimReachingDefinitions(llvm::Function *F, llvm::AAResults *AA,
                                 llvm::MemorySSA *MSSA,
                                 EliminationOptions Opts = {});
 
+// TranslAPA baseline: same front-end (path-expression DAG), but interpret each
+// summary with the closed-form Gen/Kill semiring (paper §4) instead of the
+// generic fixpoint interpreter. Records the fold time in
+// SolveDiagnostics::interp_time_us. Reaching definitions is a separable Gen/Kill
+// problem, so the mechanically-translated result equals the generic result.
+ReachingDefinitionsResult
+runIntraTranslApaReachingDefinitions(llvm::Function *F,
+                                     llvm::AAResults *AA = nullptr,
+                                     EliminationOptions Opts = {});
+
 } // namespace elimination
 
 #endif // DATAFLOW_APA_CLIENTS_LLVM_INTRA_REACHINGDEFINITIONS_H_

--- a/include/Dataflow/APA/Baseline/TranslAPA/AtomTranslator.h
+++ b/include/Dataflow/APA/Baseline/TranslAPA/AtomTranslator.h
@@ -1,0 +1,181 @@
+#ifndef DATAFLOW_APA_BASELINE_TRANSLAPA_ATOMTRANSLATOR_H_
+#define DATAFLOW_APA_BASELINE_TRANSLAPA_ATOMTRANSLATOR_H_
+
+// TranslAPA baseline — mechanical Gen/Kill extraction (paper §3, §4.2).
+//
+// The paper's translation is "mechanical": it never looks at what a dataflow
+// fact *means*, only at the behavior of the IDA abstract transformer over the
+// finite fact universe D. This translator realizes that claim generically by
+// PROBING an existing framework transfer function.
+//
+// For a separable (Gen/Kill) transfer f(x) = Gen | (x \ Kill):
+//   * Gen  = f({})                         -- facts generated unconditionally
+//   * fact d is killed  iff  d not in f({d})
+// so a per-atom (Gen, Kill) pair is recovered with |D|+1 probes of the
+// client's own applyTransfer. No per-client hand translation is required; the
+// client only supplies (1) the finite fact universe and (2) its applyTransfer.
+//
+// This class is intentionally decoupled from IntraEliminationProblem: it takes
+// the fact universe and a plain apply callable, so the same code serves both
+// the real solver Driver and lightweight unit tests. The fact type is any
+// set-like container (default ctor, insert(v), count(v), value_type) — e.g.
+// std::set<int> or std::set<const llvm::Value*>.
+
+#include "Dataflow/APA/Baseline/TranslAPA/GenKillSemiring.h"
+
+#include "llvm/ADT/BitVector.h"
+
+#include <cstdint>
+#include <functional>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+namespace elimination {
+namespace translapa {
+
+// Element type of a set-like fact container. Prefers the container's own
+// value_type (e.g. std::set), and falls back to its iterator's value_type for
+// bitmap-backed containers that only expose the element type on the iterator
+// (e.g. the upstream IndexedSet, whose class scope has no value_type).
+namespace detail {
+template <typename C, typename = void> struct FactElementType {
+  using type = typename C::const_iterator::value_type;
+};
+template <typename C>
+struct FactElementType<C, std::void_t<typename C::value_type>> {
+  using type = typename C::value_type;
+};
+} // namespace detail
+
+// Mechanical (Gen, Kill) extractor for a single transfer atom type.
+//
+//   TransferT : the atom type carried by PathExprFactory (e.g. int, Instruction*)
+//   FactT     : set-like fact container; its element type is deduced via
+//               detail::FactElementType (value_type, or iterator value_type)
+template <typename TransferT, typename FactT> class GenKillAtomTranslator {
+public:
+  using FactVal = typename detail::FactElementType<FactT>::type;
+  using ApplyFn = std::function<FactT(const TransferT &, const FactT &)>;
+
+  // Universe: the finite, ordered set of dataflow facts. Bit i in every
+  // produced element corresponds to Universe[i].
+  //
+  // Separable: when the client transfer is a genuine Gen/Kill (separable)
+  // function, extraction uses the O(|U|) fast path (2 probes/atom) instead of
+  // the general O(|U|^2) singleton probing. See extract() for the derivation.
+  GenKillAtomTranslator(std::vector<FactVal> Universe, ApplyFn Apply,
+                        bool Separable = false)
+      : Universe(std::move(Universe)), Apply(std::move(Apply)),
+        Separable(Separable) {
+    Index.reserve(this->Universe.size());
+    for (std::uint32_t I = 0; I < this->Universe.size(); ++I) {
+      Index.emplace(this->Universe[I], I);
+    }
+    if (Separable) {
+      for (const auto &V : this->Universe) {
+        AllFacts.insert(V);
+      }
+    }
+  }
+
+  unsigned universeSize() const {
+    return static_cast<unsigned>(Universe.size());
+  }
+
+  // Translate one atom to its (Gen, Kill) element, caching by transfer value
+  // when TransferT is hashable/comparable (the common case: pointers/ints).
+  GenKillFact translate(const TransferT &T) const {
+    if constexpr (isCacheable<TransferT>()) {
+      auto It = Cache.find(T);
+      if (It != Cache.end()) {
+        return It->second;
+      }
+      GenKillFact F = extract(T);
+      Cache.emplace(T, F);
+      return F;
+    } else {
+      return extract(T);
+    }
+  }
+
+  // Map a client fact set into the universe bit space (used for the initial
+  // fact and for differential comparison).
+  llvm::BitVector toBits(const FactT &S) const {
+    llvm::BitVector B(universeSize(), false);
+    for (const auto &V : S) {
+      auto It = Index.find(V);
+      if (It != Index.end()) {
+        B.set(It->second);
+      }
+    }
+    return B;
+  }
+
+  // Map a universe bit set back to a client fact set.
+  FactT fromBits(const llvm::BitVector &B) const {
+    FactT S;
+    for (int I = B.find_first(); I != -1; I = B.find_next(I)) {
+      S.insert(Universe[static_cast<std::size_t>(I)]);
+    }
+    return S;
+  }
+
+  const std::vector<FactVal> &universe() const { return Universe; }
+
+private:
+  template <typename T> static constexpr bool isCacheable() {
+    return std::is_pointer<T>::value || std::is_integral<T>::value;
+  }
+
+  GenKillFact extract(const TransferT &T) const {
+    const unsigned N = universeSize();
+    llvm::BitVector Gen(N, false);
+    llvm::BitVector Kill(N, false);
+
+    // Gen = f({}).
+    FactT GenSet = Apply(T, FactT{});
+    for (const auto &V : GenSet) {
+      auto It = Index.find(V);
+      if (It != Index.end()) {
+        Gen.set(It->second);
+      }
+    }
+
+    if (Separable) {
+      // Fast path for separable f(x) = Gen | (x \ K). Then f(U) = Gen | (U\K),
+      // so U \ f(U) = (U\Gen) & K = K\Gen, and f(x) = Gen | (x \ (K\Gen)) still
+      // holds. Thus Kill := U \ f(U) is a valid representation using 2 probes.
+      FactT Out = Apply(T, AllFacts);
+      for (std::uint32_t I = 0; I < N; ++I) {
+        if (Out.count(Universe[I]) == 0) {
+          Kill.set(I);
+        }
+      }
+      return {std::move(Gen), std::move(Kill)};
+    }
+
+    // General path: fact d is killed iff d not in f({d}). O(|U|) probes.
+    for (std::uint32_t I = 0; I < N; ++I) {
+      FactT Single;
+      Single.insert(Universe[I]);
+      FactT Out = Apply(T, Single);
+      if (Out.count(Universe[I]) == 0) {
+        Kill.set(I);
+      }
+    }
+    return {std::move(Gen), std::move(Kill)};
+  }
+
+  std::vector<FactVal> Universe;
+  std::unordered_map<FactVal, std::uint32_t> Index;
+  ApplyFn Apply;
+  bool Separable = false;
+  FactT AllFacts;
+  mutable std::unordered_map<TransferT, GenKillFact> Cache;
+};
+
+} // namespace translapa
+} // namespace elimination
+
+#endif // DATAFLOW_APA_BASELINE_TRANSLAPA_ATOMTRANSLATOR_H_

--- a/include/Dataflow/APA/Baseline/TranslAPA/Driver.h
+++ b/include/Dataflow/APA/Baseline/TranslAPA/Driver.h
@@ -1,0 +1,155 @@
+#ifndef DATAFLOW_APA_BASELINE_TRANSLAPA_DRIVER_H_
+#define DATAFLOW_APA_BASELINE_TRANSLAPA_DRIVER_H_
+
+// TranslAPA baseline — driver glue.
+//
+// The framework's elimination front-end already produces one path expression
+// per node (Results.ExprTo(N), a hash-consed PathExprFactory DAG). This is the
+// paper's path expression p. The baseline keeps that front-end verbatim and
+// only swaps the interpreter: instead of SolverContext::eval (generic transfer
+// re-application with Star iterated to a fixpoint), it folds p with the closed-
+// form Gen/Kill semiring (paper §4) in a single memoized bottom-up pass.
+//
+// foldFillGenKill() is the reusable core: given a solved result and a
+// translator that maps atoms to (Gen, Kill), it overwrites each node's IN fact
+// with the semiring interpretation and returns the fold wall-clock time (µs).
+// Client wrappers (e.g. reaching definitions) build the translator and call it.
+
+#include "Dataflow/APA/Baseline/TranslAPA/FoldInterpreter.h"
+#include "Dataflow/APA/Baseline/TranslAPA/GenKillSemiring.h"
+#include "Dataflow/APA/Core/Problem.h"
+#include "Dataflow/APA/Core/Result.h"
+
+#include <chrono>
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+
+namespace elimination {
+namespace translapa {
+
+// Translator concept (duck-typed): must provide
+//   unsigned      universeSize() const;
+//   GenKillFact   translate(const transfer_t&) const;   // mechanical (Gen,Kill)
+//   llvm::BitVector toBits(const fact_t&) const;         // fact -> universe bits
+//   fact_t        fromBits(const llvm::BitVector&) const;// universe bits -> fact
+//
+// Overwrites Results.IN(N) for every node whose path expression exists; returns
+// fold time in microseconds. Unreachable nodes (no ExprTo) are left untouched.
+template <typename Domain, typename Translator>
+std::size_t foldFillGenKill(
+    const IntraEliminationProblem<Domain> &P,
+    DataFlowResultT<typename Domain::n_t, typename Domain::fact_t,
+                    typename Domain::transfer_t> &Results,
+    const Translator &Tr) {
+  using transfer_t = typename Domain::transfer_t;
+
+  GenKillSemiring S(Tr.universeSize());
+  auto Interp = makeFoldInterpreter<transfer_t>(
+      S, [&Tr](const transfer_t &T) { return Tr.translate(T); });
+
+  const llvm::BitVector Init = Tr.toBits(P.initialFact());
+  const auto &ConstResults = Results; // use the non-inserting const ExprTo
+
+  const auto Start = std::chrono::steady_clock::now();
+  for (const auto &N : P.nodes()) {
+    auto E = ConstResults.ExprTo(N);
+    if (!E) {
+      continue;
+    }
+    GenKillFact Summary = Interp.fold(E);
+    Results.IN(N) = Tr.fromBits(S.apply(Summary, Init));
+  }
+  return static_cast<std::size_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - Start)
+          .count());
+}
+
+// Split timing: mechanical extraction (one-time construction, paper's
+// "construction") vs the per-query closed-form fold ("evaluation"). Warms the
+// translator's atom cache in a first pass, then folds with cache hits so the
+// two costs are measured apart. Returns {extract_us, fold_us}.
+struct FoldTimings final {
+  std::size_t extract_us = 0;
+  std::size_t fold_us = 0;
+};
+
+template <typename Domain, typename Translator>
+FoldTimings foldFillGenKillTimed(
+    const IntraEliminationProblem<Domain> &P,
+    DataFlowResultT<typename Domain::n_t, typename Domain::fact_t,
+                    typename Domain::transfer_t> &Results,
+    const Translator &Tr) {
+  using transfer_t = typename Domain::transfer_t;
+  using Factory = PathExprFactory<transfer_t>;
+  using Expr = typename Factory::Expr;
+  using Kind = typename Factory::Kind;
+
+  const auto &ConstResults = Results;
+
+  // Pass 1: warm the atom cache over the unique DAG nodes (extraction).
+  FoldTimings Out;
+  const auto ExtractStart = std::chrono::steady_clock::now();
+  {
+    std::unordered_map<const Expr *, bool> Seen;
+    std::vector<const Expr *> Stack;
+    for (const auto &N : P.nodes()) {
+      auto E = ConstResults.ExprTo(N);
+      if (E) {
+        Stack.push_back(E.get());
+      }
+    }
+    while (!Stack.empty()) {
+      const Expr *E = Stack.back();
+      Stack.pop_back();
+      if (E == nullptr || !Seen.emplace(E, true).second) {
+        continue;
+      }
+      switch (E->K) {
+      case Kind::Atom:
+        (void)Tr.translate(*E->Transfer);
+        break;
+      case Kind::Union:
+      case Kind::Concat:
+        Stack.push_back(E->L.get());
+        Stack.push_back(E->R.get());
+        break;
+      case Kind::Star:
+        Stack.push_back(E->L.get());
+        break;
+      default:
+        break;
+      }
+    }
+  }
+  Out.extract_us = static_cast<std::size_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - ExtractStart)
+          .count());
+
+  // Pass 2: fold with a warm cache (evaluation).
+  GenKillSemiring S(Tr.universeSize());
+  auto Interp = makeFoldInterpreter<transfer_t>(
+      S, [&Tr](const transfer_t &T) { return Tr.translate(T); });
+  const llvm::BitVector Init = Tr.toBits(P.initialFact());
+  const auto FoldStart = std::chrono::steady_clock::now();
+  for (const auto &N : P.nodes()) {
+    auto E = ConstResults.ExprTo(N);
+    if (!E) {
+      continue;
+    }
+    GenKillFact Summary = Interp.fold(E);
+    Results.IN(N) = Tr.fromBits(S.apply(Summary, Init));
+  }
+  Out.fold_us = static_cast<std::size_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - FoldStart)
+          .count());
+  return Out;
+}
+
+} // namespace translapa
+} // namespace elimination
+
+#endif // DATAFLOW_APA_BASELINE_TRANSLAPA_DRIVER_H_

--- a/include/Dataflow/APA/Baseline/TranslAPA/FoldInterpreter.h
+++ b/include/Dataflow/APA/Baseline/TranslAPA/FoldInterpreter.h
@@ -1,0 +1,93 @@
+#ifndef DATAFLOW_APA_BASELINE_TRANSLAPA_FOLDINTERPRETER_H_
+#define DATAFLOW_APA_BASELINE_TRANSLAPA_FOLDINTERPRETER_H_
+
+// TranslAPA baseline — memoized bottom-up fold over the path-expression DAG.
+//
+// APA's semantic function D is defined for an arbitrary path expression by the
+// algebraic composition rules of the semiring. This interpreter evaluates the
+// hash-consed PathExprFactory<TransferT> DAG produced by the framework's
+// elimination front-end (Results.ExprTo(N)) into one semiring element per
+// UNIQUE node, memoized on the Expr pointer.
+//
+// Cost is O(#unique DAG nodes), versus SolverContext::eval which recurses over
+// the expanded tree and iterates Star to a fixpoint. Same path expression p,
+// different semantic function — the apples-to-apples comparison this baseline
+// exists for.
+
+#include "Dataflow/APA/Core/PathExpr.h"
+
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+
+namespace elimination {
+namespace translapa {
+
+// SemiringT must provide: type Elem; and zero()/one()/star(Elem)/
+// seq(Elem,Elem)/join(Elem,Elem). AtomFn maps a const TransferT& to Elem.
+template <typename TransferT, typename SemiringT, typename AtomFn>
+class FoldInterpreter {
+public:
+  using Factory = PathExprFactory<TransferT>;
+  using Ref = typename Factory::Ref;
+  using Expr = typename Factory::Expr;
+  using Kind = typename Factory::Kind;
+  using Elem = typename SemiringT::Elem;
+
+  FoldInterpreter(const SemiringT &S, AtomFn Atom) : S(S), Atom(std::move(Atom)) {}
+
+  Elem fold(const Ref &E) { return foldPtr(E.get()); }
+
+  std::size_t uniqueNodesVisited() const { return Memo.size(); }
+
+private:
+  Elem foldPtr(const Expr *E) {
+    if (E == nullptr) {
+      return S.zero();
+    }
+    auto It = Memo.find(E);
+    if (It != Memo.end()) {
+      return It->second;
+    }
+    Elem V = compute(E);
+    Memo.emplace(E, V);
+    return V;
+  }
+
+  Elem compute(const Expr *E) {
+    switch (E->K) {
+    case Kind::Zero:
+      return S.zero();
+    case Kind::One:
+      return S.one();
+    case Kind::Atom:
+      return Atom(*E->Transfer);
+    case Kind::Union:
+      return S.join(foldPtr(E->L.get()), foldPtr(E->R.get()));
+    case Kind::Concat:
+      // Concat.L is applied first (SolverContext::eval convention), so seq's
+      // "L then R" orientation matches.
+      return S.seq(foldPtr(E->L.get()), foldPtr(E->R.get()));
+    case Kind::Star:
+      return S.star(foldPtr(E->L.get()));
+    }
+    return S.zero();
+  }
+
+  const SemiringT &S;
+  AtomFn Atom;
+  std::unordered_map<const Expr *, Elem> Memo;
+};
+
+// Deduction helper so callers can write makeFoldInterpreter(S, atomFn) without
+// spelling out the AtomFn type.
+template <typename TransferT, typename SemiringT, typename AtomFn>
+FoldInterpreter<TransferT, SemiringT, AtomFn>
+makeFoldInterpreter(const SemiringT &S, AtomFn Atom) {
+  return FoldInterpreter<TransferT, SemiringT, AtomFn>(S, std::move(Atom));
+}
+
+} // namespace translapa
+} // namespace elimination
+
+#endif // DATAFLOW_APA_BASELINE_TRANSLAPA_FOLDINTERPRETER_H_

--- a/include/Dataflow/APA/Baseline/TranslAPA/GenKillSemiring.h
+++ b/include/Dataflow/APA/Baseline/TranslAPA/GenKillSemiring.h
@@ -1,0 +1,115 @@
+#ifndef DATAFLOW_APA_BASELINE_TRANSLAPA_GENKILLSEMIRING_H_
+#define DATAFLOW_APA_BASELINE_TRANSLAPA_GENKILLSEMIRING_H_
+
+// TranslAPA baseline — Gen/Kill semiring (paper §4).
+//
+// This is the closed-form APA semantic function for separable (Gen/Kill)
+// dataflow problems produced by the mechanical IDA->APA translation of
+//   Zhou, Wang, Wang. "Mechanically Translating Iterative Dataflow Analysis to
+//   Algebraic Program Analysis." OOPSLA 2026.
+//
+// A program property is a pair (Gen, Kill) of subsets of the finite fact
+// universe D, represented as fixed-width llvm::BitVectors. The element denotes
+// the transfer function
+//     f(x) = Gen | (x & ~Kill).
+//
+// The composition rules (§4.3) are closed form; crucially star() is O(1) with
+// NO fixpoint iteration, which is the whole point of the algebraic baseline and
+// the key contrast with the framework's generic tree-walking interpreter
+// (Solver/SolverContext.h::eval, which iterates Star to a lattice fixpoint).
+//
+// Orientation contract: seq(L, R) means "L applied first, then R", matching
+// PathExprFactory Concat semantics used by SolverContext::eval (Concat.L is
+// evaluated on the incoming fact first, then Concat.R on the result). See the
+// derivation in seq() below.
+
+#include "llvm/ADT/BitVector.h"
+
+#include <utility>
+
+namespace elimination {
+namespace translapa {
+
+// (Gen, Kill) program property over a universe of |D| facts. Both vectors have
+// width |D|; bit i corresponds to fact i in the translator's index space.
+struct GenKillFact {
+  llvm::BitVector Gen;
+  llvm::BitVector Kill;
+
+  bool operator==(const GenKillFact &Other) const {
+    return Gen == Other.Gen && Kill == Other.Kill;
+  }
+  bool operator!=(const GenKillFact &Other) const { return !(*this == Other); }
+};
+
+// Closed-form Gen/Kill semiring. Constructed with the universe size |D| so that
+// every produced element has consistent bit width.
+class GenKillSemiring {
+public:
+  using Elem = GenKillFact;
+
+  explicit GenKillSemiring(unsigned UniverseSize) : N(UniverseSize) {}
+
+  unsigned universeSize() const { return N; }
+
+  // Multiplicative unit (empty path ε): identity function f(x) = x.
+  //   Gen = {}, Kill = {}.
+  Elem one() const { return {emptyBV(), emptyBV()}; }
+
+  // Additive unit (no path, PathExprFactory Zero): the union-neutral element.
+  // f(x) must be absorbed by join, so Gen = {} and Kill = D (full), since
+  // join's Kill is intersection (Kill & D = Kill) and Gen is union (Gen | {}).
+  Elem zero() const { return {emptyBV(), fullBV()}; }
+
+  // Atom: the (Gen, Kill) parameters of a single edge's transfer, as supplied
+  // by the mechanical translator.
+  Elem atom(llvm::BitVector Gen, llvm::BitVector Kill) const {
+    return {std::move(Gen), std::move(Kill)};
+  }
+
+  // Sequence "L then R" = R . L. Derivation:
+  //   R(L(x)) = R.Gen | (L(x) & ~R.Kill)
+  //           = R.Gen | ((L.Gen | (x & ~L.Kill)) & ~R.Kill)
+  //           = R.Gen | (L.Gen & ~R.Kill) | (x & ~(L.Kill | R.Kill))
+  // hence Gen = R.Gen | (L.Gen & ~R.Kill), Kill = L.Kill | R.Kill
+  // (paper's Gen_{12}=Gen_2 | (Gen_1\Kill_2), Kill_{12}=Kill_1|Kill_2).
+  Elem seq(const Elem &L, const Elem &R) const {
+    llvm::BitVector Gen = L.Gen;
+    Gen.reset(R.Kill); // L.Gen \ R.Kill
+    Gen |= R.Gen;
+    llvm::BitVector Kill = L.Kill;
+    Kill |= R.Kill;
+    return {std::move(Gen), std::move(Kill)};
+  }
+
+  // Choice (branch join): Gen = Gen_1 | Gen_2, Kill = Kill_1 & Kill_2 (§4.3.2).
+  Elem join(const Elem &L, const Elem &R) const {
+    llvm::BitVector Gen = L.Gen;
+    Gen |= R.Gen;
+    llvm::BitVector Kill = L.Kill;
+    Kill &= R.Kill;
+    return {std::move(Gen), std::move(Kill)};
+  }
+
+  // Kleene star: Gen* = Gen, Kill* = {} (§4.3.3). Closed form, no iteration.
+  Elem star(const Elem &A) const { return {A.Gen, emptyBV()}; }
+
+  // Apply the summary to an incoming fact set: f(In) = Gen | (In & ~Kill).
+  llvm::BitVector apply(const Elem &S, const llvm::BitVector &In) const {
+    llvm::BitVector Out = In;
+    Out.reset(S.Kill); // In \ Kill
+    Out |= S.Gen;
+    return Out;
+  }
+
+private:
+  llvm::BitVector emptyBV() const { return llvm::BitVector(N, false); }
+  llvm::BitVector fullBV() const { return llvm::BitVector(N, true); }
+
+  unsigned N;
+};
+
+} // namespace translapa
+} // namespace elimination
+
+#endif // DATAFLOW_APA_BASELINE_TRANSLAPA_GENKILLSEMIRING_H_

--- a/include/Dataflow/APA/Core/InterResult.h
+++ b/include/Dataflow/APA/Core/InterResult.h
@@ -2,6 +2,7 @@
 #define DATAFLOW_APA_CORE_INTERRESULT_H_
 
 #include "Dataflow/APA/Core/Options.h"
+#include "Dataflow/APA/EAN/DagStats.h"
 #include "Dataflow/Mono/Solver/CallStringSolver.h"
 
 #include <vector>
@@ -15,6 +16,21 @@ struct InterSummarySolveDiagnostics final {
   std::size_t equation_edge_count = 0;
   std::size_t scc_count = 0;
   std::size_t cyclic_scc_count = 0;
+  // EAN/Greedy post-pass instrumentation (see ForwardInterSummarySolver). All
+  // zero/empty unless the summary solver ran.
+  //   gen_time_us    – build the equation graph + solve it into path exprs,
+  //   norm_time_us   – EAN/Greedy optimization of the summary batch (0 if off),
+  //   interp_time_us – evaluate summaries into client facts.
+  // summary_before/after are the FULL structural stats of the summary batch
+  // pre/post optimization (equal when no pass ran). Within a single EAN/Greedy
+  // run, summary_before is the raw (Default-configuration) batch and
+  // summary_after is the optimized one, so one run yields the Default↔EAN
+  // reduction directly. These fill the paper's interprocedural Table VI/VII.
+  std::size_t gen_time_us = 0;
+  std::size_t norm_time_us = 0;
+  std::size_t interp_time_us = 0;
+  ean::DagStats summary_before;
+  ean::DagStats summary_after;
 };
 
 template <unsigned K, typename FactT, typename TransferT,

--- a/include/Dataflow/APA/Core/Options.h
+++ b/include/Dataflow/APA/Core/Options.h
@@ -3,6 +3,11 @@
 
 #include <cstddef>
 
+#include "Dataflow/APA/EAN/Budget.h"
+#include "Dataflow/APA/EAN/CostModel.h"
+#include "Dataflow/APA/EAN/ExtractOptions.h"
+#include "Dataflow/APA/EAN/LawProfile.h"
+
 namespace elimination {
 
 enum class EliminationMethod {
@@ -12,6 +17,19 @@ enum class EliminationMethod {
   ADTSimple,
   // Paper-style ADT + path-expression construction (requires reducible info).
   ADTDelayed,
+};
+
+// Pivot-order policy for the state-elimination engine (paper's "Order"
+// configuration). The order never changes the final all-pairs result (the
+// k-loop is a Floyd–Warshall closure), only the peak construction cost — see
+// Solver/EliminationOrder.h.
+enum class OrderingPolicy {
+  // Baseline: reverse-topological order for reducible problems, identity
+  // otherwise (unchanged historical behavior).
+  Default,
+  // Cost-aware greedy minimum-product ordering that minimizes the
+  // predecessor–successor product driving Eq. 1's intermediate growth.
+  CostAware,
 };
 
 enum class OnNonConvergentStar {
@@ -62,16 +80,105 @@ struct SolveDiagnostics final {
   ADTRejectionReason adt_rejection_reason = ADTRejectionReason::None;
   std::size_t star_iterations_total = 0;
   bool max_star_hit = false;
+  // Peak unique path-expression DAG nodes reachable from the WHOLE elimination
+  // matrix at any point during construction (state elimination only). Populated
+  // only when EliminationOptions::MeasurePeakNodes is set; 0 otherwise. This is
+  // the paper's RQ3 "peak construction nodes" metric.
+  std::size_t peak_matrix_nodes = 0;
+  // Stage timings (microseconds), recorded by the state-elimination path:
+  //   generation    = build matrix + eliminate intermediates (raw DAG),
+  //   normalization = EAN optimization pass (0 unless EnableEAN),
+  //   interpretation = evaluating summaries into client facts.
+  // These fill the paper's Table VII stage columns.
+  std::size_t gen_time_us = 0;
+  std::size_t norm_time_us = 0;
+  std::size_t interp_time_us = 0;
 };
 
 struct EliminationOptions final {
   EliminationMethod Method = EliminationMethod::StateElimination;
+  // Pivot-order policy for the state-elimination engine. Default preserves the
+  // historical baseline order; CostAware selects the paper's "Order" policy.
+  OrderingPolicy Ordering = OrderingPolicy::Default;
   OnNonConvergentStar NonConvergentStarPolicy = OnNonConvergentStar::Fail;
   // 0 means "use Problem.maxStarIterations()".
   std::size_t MaxStarIterations = 0;
   // Reserved for future conditional collection. Diagnostics are currently
   // recorded unconditionally by the solver and attached to result metadata.
   bool RecordDiagnostics = true;
+
+  // Opt-in RQ3 instrumentation: when set, the state-elimination engine records
+  // SolveDiagnostics::peak_matrix_nodes (peak unique DAG nodes across the whole
+  // matrix during construction). Default off — adds a per-pivot reachability
+  // scan, so it is enabled only by the evaluation harness.
+  bool MeasurePeakNodes = false;
+
+  // EAN (Equality-saturation Algebraic Normalizer) post-optimization. When
+  // enabled, the solver runs EAN on the batch of path-expression summaries
+  // before interpreting them (see SolverContext::applyEAN). Default off, so the
+  // baseline "Default" configuration is unchanged. The default law profile is
+  // universally safe (left distributivity only); distributive clients may set a
+  // richer profile (RightDistributive/Sliding/...) per their algebra.
+  bool EnableEAN = false;
+  ean::LawProfile EANLaws = ean::LawProfile::safeMinimal();
+  ean::CostModel EANCost = ean::CostModel::uniform();
+  ean::Budget EANBudget = ean::Budget::unbounded();
+  ean::ExtractOptions EANExtract = {};
+  // Greedy post-pass (paper's "Greedy" config): deterministic one-pass prefix
+  // factorization, no e-graph, no retained alternatives. Mutually exclusive
+  // with EnableEAN (EAN takes precedence if both set). Default off.
+  bool EnableGreedy = false;
+  // Invocation gate: run EAN only on batches whose raw unique-node count is at
+  // least this (0 = always run). Copied into EANExtract.gateMinNodes at use.
+  std::size_t EANMinNodes = 0;
+  // Monotone guard: EAN returns the input if its output has more unique nodes
+  // (never degrade an already-compact input). Copied into EANExtract at use.
+  bool EANMonotone = false;
+  // Interpret each summary this many times (>=1). Amortization knob for RQ2:
+  // reveals the per-query interpretation cost so EAN's cheaper IR can be
+  // weighed against its one-time normalization cost. Does not change results.
+  std::size_t InterpRepeat = 1;
+
+  // Memoizing (transformer-composition) interpretation. When set, the generic
+  // engines SKIP the tree-walking interpreter — they still build/optimize the
+  // path-expression ExprTo batch, but leave IN facts for the CLIENT to fill via
+  // a memoizing interpreter that evaluates each unique DAG node once (cost ∝
+  // unique nodes instead of the expanded tree). This only makes sense for a
+  // relational client whose fact is a transformer and whose initialFact is the
+  // compositional unit (e.g. the affine-equalities client); other clients must
+  // not set it (their IN facts would be left empty). Default off.
+  bool InterpMemo = false;
+};
+
+// EAN/Greedy post-optimization configuration for the interprocedural
+// path-summary solver (ForwardInterSummarySolver). Mirrors the EAN-relevant
+// subset of EliminationOptions so the intra and inter stories share identical
+// knobs and defaults. All fields default to a no-op pass (EnableEAN and
+// EnableGreedy both false), so the interprocedural baseline is unchanged.
+//
+// Soundness note: the interprocedural summary interpreter composes atoms the
+// same way as the intra interpreter (Concat = sequential apply, Union = merge),
+// so left distributivity holds unconditionally and the default safe-minimal law
+// profile preserves every client's results. Distributive clients may opt into a
+// richer profile per their algebra.
+struct InterEANOptions final {
+  // Run EAN on the batch of context summaries before interpreting them.
+  bool EnableEAN = false;
+  ean::LawProfile EANLaws = ean::LawProfile::safeMinimal();
+  ean::CostModel EANCost = ean::CostModel::uniform();
+  ean::Budget EANBudget = ean::Budget::unbounded();
+  ean::ExtractOptions EANExtract = {};
+  // Greedy post-pass (paper's "Greedy" config). Mutually exclusive with
+  // EnableEAN (EAN takes precedence if both set). Default off.
+  bool EnableGreedy = false;
+  // Invocation gate: run EAN only when the batch's raw unique-node count is at
+  // least this (0 = always). Copied into EANExtract.gateMinNodes at use.
+  std::size_t EANMinNodes = 0;
+  // Monotone guard: return the input batch if EAN's output has more unique
+  // nodes. Copied into EANExtract.monotoneGuard at use.
+  bool EANMonotone = false;
+  // Interpret each summary this many times (>=1). Amortization knob for RQ2.
+  std::size_t InterpRepeat = 1;
 };
 
 } // namespace elimination

--- a/include/Dataflow/APA/Core/PathExpr.h
+++ b/include/Dataflow/APA/Core/PathExpr.h
@@ -42,16 +42,38 @@ public:
   }
 
   Ref atom(TransferT T) const {
-    if constexpr (is_equality_comparable<TransferT>::value) {
+    if constexpr (is_equality_comparable<TransferT>::value &&
+                  is_std_hashable<TransferT>::value) {
+      // Hash-consed dedup: O(1) amortized instead of the O(atoms) linear scan
+      // below. Returns the same unique node the scan would (atoms are unique by
+      // value), so the exported DAG is byte-identical — only faster. Enabled
+      // whenever TransferT is both hashable and comparable (e.g. Instruction*
+      // intraprocedurally, and the interprocedural summary atom).
+      const std::size_t H = std::hash<TransferT>{}(T);
+      const auto Range = AtomIndex.equal_range(H);
+      for (auto It = Range.first; It != Range.second; ++It) {
+        if (*It->second->Transfer == T) {
+          return It->second;
+        }
+      }
+      auto Node = std::make_shared<Expr>(Kind::Atom, std::move(T));
+      AtomIndex.emplace(H, Node);
+      return Node;
+    } else if constexpr (is_equality_comparable<TransferT>::value) {
       for (const auto &Existing : Atoms) {
         if (*Existing->Transfer == T) {
           return Existing;
         }
       }
+      auto Node = std::make_shared<Expr>(Kind::Atom, std::move(T));
+      Atoms.push_back(Node);
+      return Node;
+    } else {
+      // Not comparable: cannot dedup, mint a fresh node each call.
+      auto Node = std::make_shared<Expr>(Kind::Atom, std::move(T));
+      Atoms.push_back(Node);
+      return Node;
     }
-    auto Node = std::make_shared<Expr>(Kind::Atom, std::move(T));
-    Atoms.push_back(Node);
-    return Node;
   }
 
   Ref unite(const Ref &A, const Ref &B) const {
@@ -123,6 +145,14 @@ private:
       T, std::void_t<decltype(std::declval<const T &>() ==
                               std::declval<const T &>())>> : std::true_type {};
 
+  template <typename T, typename = void>
+  struct is_std_hashable : std::false_type {};
+
+  template <typename T>
+  struct is_std_hashable<
+      T, std::void_t<decltype(std::declval<std::hash<T>>()(
+             std::declval<const T &>()))>> : std::true_type {};
+
   struct BinaryKey final {
     const Expr *L = nullptr;
     const Expr *R = nullptr;
@@ -145,6 +175,9 @@ private:
   }
 
   mutable std::vector<Ref> Atoms;
+  // Hash index over atom Transfer values (used when TransferT is hashable);
+  // buckets map hash(Transfer) -> atom node for O(1) amortized hash-consing.
+  mutable std::unordered_multimap<std::size_t, Ref> AtomIndex;
   mutable std::unordered_map<BinaryKey, Ref, BinaryKeyHash> Unions;
   mutable std::unordered_map<BinaryKey, Ref, BinaryKeyHash> Concats;
   mutable std::unordered_map<const Expr *, Ref> Stars;

--- a/include/Dataflow/APA/EAN/AtomTable.h
+++ b/include/Dataflow/APA/EAN/AtomTable.h
@@ -1,0 +1,61 @@
+#ifndef DATAFLOW_APA_EAN_ATOMTABLE_H_
+#define DATAFLOW_APA_EAN_ATOMTABLE_H_
+
+// AtomTable: a bijection between the opaque transfer atoms of a
+// PathExprFactory<TransferT> and the small integer ids that PathLang encodes
+// into "atom#<id>" operator names.
+//
+// Deduplication key is the Expr* pointer of the atom node, NOT the TransferT
+// value. Within one PathExprFactory an atom is hash-consed, so "same atom" ==
+// "same Ref" == "same pointer"; this judgement does not depend on whether
+// TransferT is equality-comparable (PathExprFactory only value-dedups atoms
+// when TransferT is comparable, and falls back to per-node identity otherwise).
+//
+// Export reuses the original Ref stored here verbatim — atoms are opaque to
+// EAN, so there is nothing to rebuild. This is valid because the owning
+// factory outlives an EAN run.
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "Dataflow/APA/Core/PathExpr.h"
+
+namespace elimination {
+namespace ean {
+
+template <typename TransferT> class AtomTable {
+public:
+  using Factory = PathExprFactory<TransferT>;
+  using Ref = typename Factory::Ref;
+  using Expr = typename Factory::Expr;
+
+  // Return the stable id for the atom `e`, allocating one on first sight.
+  // Precondition: e && e->K == Kind::Atom.
+  std::uint32_t intern(const Ref &e) {
+    const Expr *key = e.get();
+    auto it = ptr_to_id_.find(key);
+    if (it != ptr_to_id_.end()) {
+      return it->second;
+    }
+    const auto id = static_cast<std::uint32_t>(id_to_atom_.size());
+    ptr_to_id_.emplace(key, id);
+    id_to_atom_.push_back(e);
+    return id;
+  }
+
+  // Recover the original atom Ref for a previously interned id.
+  // Precondition: id < size().
+  const Ref &atom(std::uint32_t id) const { return id_to_atom_[id]; }
+
+  std::size_t size() const { return id_to_atom_.size(); }
+
+private:
+  std::unordered_map<const Expr *, std::uint32_t> ptr_to_id_;
+  std::vector<Ref> id_to_atom_;
+};
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_ATOMTABLE_H_

--- a/include/Dataflow/APA/EAN/BatchExtract.h
+++ b/include/Dataflow/APA/EAN/BatchExtract.h
@@ -1,0 +1,290 @@
+#ifndef DATAFLOW_APA_EAN_BATCHEXTRACT_H_
+#define DATAFLOW_APA_EAN_BATCHEXTRACT_H_
+
+// Reuse-aware batch extraction (paper §III.D, Algorithm 2): pick one e-node per
+// e-class to minimize the shared-DAG objective (Eq. 5), not the additive tree
+// cost. Two ingredients:
+//
+//  * cycleSafeExtract — a bounded relaxation (Bellman–Ford style) that assigns
+//    each class its cheapest node, where a node is eligible only once ALL its
+//    children already have a finite cost. This guarantees the selected DAG is
+//    finite even when the e-graph is cyclic (star unfolding, M5). On an acyclic
+//    graph it degenerates to ordinary bottom-up extraction.
+//
+//  * the reuse loop — starting from the tree solution, repeatedly count
+//    references in the current selected DAG and re-extract with a sublinear
+//    discount on multiply-referenced classes, biasing the extractor toward
+//    reuse. Each candidate is scored by the TRUE Eq. 5 objective and the best
+//    is kept, so an inaccurate discount can never make the result worse than
+//    the initial tree extraction (paper's safety net; not a claim of DAG
+//    optimality).
+
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "Dataflow/APA/EAN/Canonical.h"
+#include "Dataflow/APA/EAN/CostFn.h"
+#include "Dataflow/APA/EAN/CostModel.h"
+#include "Dataflow/APA/EAN/ExtractOptions.h"
+#include "Dataflow/APA/EAN/PathLang.h"
+
+namespace elimination {
+namespace ean {
+
+// The chosen representative e-node per (canonical) e-class id.
+using Selection = std::unordered_map<std::uint32_t, PathLang>;
+
+struct ExtractResult {
+  Selection chosen;
+  double dagCost = 0.0;
+};
+
+namespace detail {
+
+constexpr double kInf = std::numeric_limits<double>::infinity();
+
+struct RelaxState {
+  Selection chosen;
+  std::unordered_map<std::uint32_t, double> cost;
+  double at(std::uint32_t c) const {
+    auto it = cost.find(c);
+    return it == cost.end() ? kInf : it->second;
+  }
+};
+
+// Cycle-safe per-class cheapest-node relaxation. `wNode(node)` is the node's own
+// weight; `disc(childClassId)` scales a child's cost when a parent consumes it
+// (used to reward reuse; 1.0 = no discount).
+//
+// Uses a parent-pointer work queue (egg-style) instead of a whole-graph
+// rescan-to-fixpoint: a class is (re)relaxed only when it is first seeded or
+// when one of its children's cost improved. Node costs are monotonically
+// non-increasing, so the queue converges to the same least fixpoint the naive
+// `for pass: for all classes` relaxation reached with a sufficient pass count
+// (the sole caller uses numberOfClasses()+1, which always suffices) — the chosen
+// representative and cost are byte-for-byte identical. `passes` is retained for
+// API compatibility and now bounds only pathological non-convergence.
+template <typename WNodeFn, typename DiscFn>
+RelaxState cycleSafeExtract(Graph &g, WNodeFn wNode, DiscFn disc,
+                            std::size_t passes) {
+  RelaxState st;
+  const auto ids = g.classIds();
+
+  std::deque<Id> worklist;
+  std::unordered_set<std::uint32_t> queued;
+  for (Id c : ids) {
+    worklist.push_back(c);
+    queued.insert(g.find(c).value());
+  }
+
+  // Generous safety cap on total relaxations so a pathological input cannot spin
+  // forever; under the auto pass count this is never reached, so output is
+  // unchanged. passes==0 would mean "no bound" but the caller never passes 0.
+  const std::size_t nclasses = ids.size() + 1;
+  const std::size_t cap =
+      passes == 0
+          ? std::numeric_limits<std::size_t>::max()
+          : (passes > std::numeric_limits<std::size_t>::max() / nclasses
+                 ? std::numeric_limits<std::size_t>::max()
+                 : passes * nclasses);
+  std::size_t steps = 0;
+
+  while (!worklist.empty()) {
+    if (++steps > cap) {
+      break;
+    }
+    Id c0 = worklist.front();
+    worklist.pop_front();
+    const std::uint32_t cid = g.find(c0).value();
+    queued.erase(cid);
+
+    const auto &cls = g[c0];
+    bool improved = false;
+    for (const PathLang &n : cls.nodes) {
+      double cost = wNode(n);
+      bool eligible = true;
+      for (Id q : n.children()) {
+        const std::uint32_t qid = g.find(q).value();
+        const double cc = st.at(qid);
+        if (cc == kInf) {
+          eligible = false;
+          break;
+        }
+        cost += cc * disc(qid);
+      }
+      if (eligible && cost < st.at(cid)) {
+        st.cost[cid] = cost;
+        st.chosen[cid] = n;
+        improved = true;
+      }
+    }
+
+    if (improved) {
+      // This class's cost improved (or became finite): re-relax every class that
+      // references it as a child.
+      for (Id p : cls.parents) {
+        const std::uint32_t pc = g.find(p).value();
+        if (queued.insert(pc).second) {
+          worklist.push_back(g.find(p));
+        }
+      }
+    }
+  }
+  return st;
+}
+
+// Reference count of each selected class in the DAG rooted at `roots` (roots
+// count as one external reference each).
+inline std::unordered_map<std::uint32_t, std::size_t>
+referenceCounts(Graph &g, const std::vector<Id> &roots,
+                const Selection &chosen) {
+  std::unordered_map<std::uint32_t, std::size_t> freq;
+  std::unordered_set<std::uint32_t> visited;
+  std::vector<std::uint32_t> stack;
+  for (Id r : roots) {
+    const std::uint32_t rid = g.find(r).value();
+    ++freq[rid];
+    stack.push_back(rid);
+  }
+  while (!stack.empty()) {
+    const std::uint32_t c = stack.back();
+    stack.pop_back();
+    if (!visited.insert(c).second) {
+      continue;
+    }
+    auto it = chosen.find(c);
+    if (it == chosen.end()) {
+      continue;
+    }
+    for (Id q : it->second.children()) {
+      const std::uint32_t qid = g.find(q).value();
+      ++freq[qid];
+      stack.push_back(qid);
+    }
+  }
+  return freq;
+}
+
+// Eq. 5: alpha*N_unique + beta*E_unique + sum_o w_o*N_o + gamma*C_repeat.
+inline double dagCost(Graph &g, const std::vector<Id> &roots,
+                      const Selection &chosen, const CostModel &cm) {
+  PathCostFn wf(cm);
+  std::unordered_set<std::uint32_t> visited;
+  std::vector<std::uint32_t> post; // post-order (children before parents)
+
+  std::function<void(std::uint32_t)> dfs = [&](std::uint32_t c) {
+    if (!visited.insert(c).second) {
+      return;
+    }
+    auto it = chosen.find(c);
+    if (it != chosen.end()) {
+      for (Id q : it->second.children()) {
+        dfs(g.find(q).value());
+      }
+    }
+    post.push_back(c);
+  };
+  for (Id r : roots) {
+    dfs(g.find(r).value());
+  }
+
+  std::size_t nUnique = post.size();
+  std::size_t eUnique = 0;
+  double opTerm = 0.0; // sum_o w_o * N_o
+  for (std::uint32_t c : post) {
+    const PathLang &n = chosen.at(c);
+    eUnique += n.children().size();
+    opTerm += wf.opWeight(n);
+  }
+
+  // Occurrence multiplicity via top-down path counts (reverse post-order is a
+  // topological order: parents before children).
+  std::unordered_map<std::uint32_t, double> mult;
+  for (Id r : roots) {
+    mult[g.find(r).value()] += 1.0;
+  }
+  for (auto it = post.rbegin(); it != post.rend(); ++it) {
+    const std::uint32_t c = *it;
+    const double mc = mult.count(c) ? mult[c] : 0.0;
+    for (Id q : chosen.at(c).children()) {
+      mult[g.find(q).value()] += mc;
+    }
+  }
+  double cRepeat = 0.0;
+  for (std::uint32_t c : post) {
+    const double mc = mult.count(c) ? mult[c] : 0.0;
+    cRepeat += (mc > 1.0 ? mc - 1.0 : 0.0) * wf.opWeight(chosen.at(c));
+  }
+
+  return cm.alpha * static_cast<double>(nUnique) +
+         cm.beta * static_cast<double>(eUnique) + opTerm + cm.gamma * cRepeat;
+}
+
+inline bool sameSelection(const Selection &a, const Selection &b) {
+  if (a.size() != b.size()) {
+    return false;
+  }
+  for (const auto &kv : a) {
+    auto it = b.find(kv.first);
+    if (it == b.end() || !(it->second == kv.second)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace detail
+
+// Extract a reuse-aware batch selection from the (clean) e-graph.
+inline ExtractResult reuseAwareExtract(Graph &g, const std::vector<Id> &roots,
+                                       const CostModel &cm,
+                                       const ExtractOptions &opts) {
+  PathCostFn wf(cm);
+  auto wNode = [&](const PathLang &n) { return wf.opWeight(n); };
+  const std::size_t passes =
+      opts.relaxPasses ? opts.relaxPasses : g.numberOfClasses() + 1;
+
+  auto noDisc = [](std::uint32_t) { return 1.0; };
+  detail::RelaxState best = detail::cycleSafeExtract(g, wNode, noDisc, passes);
+  double bestCost = detail::dagCost(g, roots, best.chosen, cm);
+
+  for (std::size_t k = 0; k < opts.reuseIters; ++k) {
+    const auto freq = detail::referenceCounts(g, roots, best.chosen);
+    auto disc = [&](std::uint32_t qid) {
+      auto it = freq.find(qid);
+      const double f = (it == freq.end()) ? 0.0 : static_cast<double>(it->second);
+      const double extra = f > 1.0 ? f - 1.0 : 0.0;
+      return 1.0 / (1.0 + opts.discountLambda * extra);
+    };
+    detail::RelaxState cand = detail::cycleSafeExtract(g, wNode, disc, passes);
+    const double candCost = detail::dagCost(g, roots, cand.chosen, cm);
+    const bool unchanged = detail::sameSelection(cand.chosen, best.chosen);
+    if (candCost < bestCost) {
+      best = std::move(cand);
+      bestCost = candCost;
+    }
+    if (unchanged) {
+      break;
+    }
+  }
+
+  return ExtractResult{std::move(best.chosen), bestCost};
+}
+
+// Scalar Eq. 5 cost of the reuse-aware best selection (plateau signal in DAG
+// mode).
+inline double reuseAwareCost(Graph &g, const std::vector<Id> &roots,
+                             const CostModel &cm, const ExtractOptions &opts) {
+  return reuseAwareExtract(g, roots, cm, opts).dagCost;
+}
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_BATCHEXTRACT_H_

--- a/include/Dataflow/APA/EAN/Budget.h
+++ b/include/Dataflow/APA/EAN/Budget.h
@@ -1,0 +1,46 @@
+#ifndef DATAFLOW_APA_EAN_BUDGET_H_
+#define DATAFLOW_APA_EAN_BUDGET_H_
+
+// Budget and stop bookkeeping for the saturation driver (paper §III.C:
+// B = ⟨B_N, B_M, B_R, B_T, B_P⟩ bounding e-nodes, applied matches, rounds,
+// wall-clock time, and consecutive rounds without an extraction improvement).
+//
+// The driver is anytime: any stopping point yields a valid extractable result.
+
+#include <cstddef>
+#include <limits>
+
+namespace elimination {
+namespace ean {
+
+struct Budget {
+  std::size_t nodeLimit = std::numeric_limits<std::size_t>::max();  // B_N (g.totalSize())
+  std::size_t matchLimit = std::numeric_limits<std::size_t>::max(); // B_M (declared; per-match enforcement lands in M5)
+  std::size_t roundLimit = std::numeric_limits<std::size_t>::max(); // B_R
+  std::size_t plateauLimit = std::numeric_limits<std::size_t>::max(); // B_P
+  double timeLimitSec = 1e30;                                       // B_T
+
+  // A generous default: effectively unbounded, so saturation runs to fixpoint.
+  static Budget unbounded() { return Budget{}; }
+};
+
+enum class StopReason {
+  Saturated,   // no phase produced a change
+  RoundLimit,  // B_R hit
+  NodeLimit,   // B_N hit
+  Plateau,     // B_P consecutive rounds without cost improvement
+  TimeLimit,   // B_T hit
+};
+
+struct SaturationStats {
+  std::size_t rounds = 0;
+  std::size_t peakNodes = 0;
+  StopReason stop = StopReason::Saturated;
+  double initCost = 0.0;
+  double finalCost = 0.0;
+};
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_BUDGET_H_

--- a/include/Dataflow/APA/EAN/Canonical.h
+++ b/include/Dataflow/APA/EAN/Canonical.h
@@ -1,0 +1,101 @@
+#ifndef DATAFLOW_APA_EAN_CANONICAL_H_
+#define DATAFLOW_APA_EAN_CANONICAL_H_
+
+// Canonical e-node builders shared by Import (raw DAG -> e-graph) and Factorize
+// (rewrite passes). These enforce the profile-relative canonical form (paper
+// invariant I2) at the point of construction:
+//   - join: canonicalize children to reps, drop 0, sort, dedup (ACI);
+//           empty -> 0, singleton -> the element itself.
+//   - seq:  canonicalize children, drop 1, annihilate on 0, keep order (no
+//           dedup); empty -> 1, singleton -> the element itself.
+//   - star: (A*)* = A*, 0* = 1* = 1.
+//
+// These are the universally-valid Kleene simplifications (the same ones the
+// baseline PathExprFactory applies), so they are unconditional. Exploratory,
+// profile-gated rewrites live elsewhere (see Factorize.h, LawProfile.h).
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "Dataflow/APA/EAN/PathLang.h"
+#include "Solvers/EGraph/Analysis.h"
+#include "Solvers/EGraph/EGraph.h"
+
+namespace elimination {
+namespace ean {
+
+// The concrete e-graph type EAN builds. No e-class analysis data is needed for
+// import, canonicalization, or factorization.
+using Graph = ::lotus::egraph::EGraph<PathLang, ::lotus::egraph::NoAnalysis<PathLang>>;
+
+namespace canon {
+
+inline Id zeroId(Graph &g) { return g.add(makeZero()); }
+inline Id oneId(Graph &g) { return g.add(makeOne()); }
+
+// Build a canonical JOIN (⊕) e-class from `members`.
+inline Id join(Graph &g, std::vector<Id> members) {
+  const Id zero = zeroId(g);
+  std::vector<Id> kept;
+  kept.reserve(members.size());
+  for (Id m : members) {
+    m = g.find(m);
+    if (m != zero) {
+      kept.push_back(m);
+    }
+  }
+  std::sort(kept.begin(), kept.end());
+  kept.erase(std::unique(kept.begin(), kept.end()), kept.end());
+  if (kept.empty()) {
+    return zero;
+  }
+  if (kept.size() == 1) {
+    return kept.front();
+  }
+  return g.add(makeJoin(std::move(kept)));
+}
+
+// Build a canonical SEQ (·) e-class from `members` (order preserved).
+inline Id seq(Graph &g, std::vector<Id> members) {
+  const Id zero = zeroId(g);
+  const Id one = oneId(g);
+  std::vector<Id> kept;
+  kept.reserve(members.size());
+  for (Id m : members) {
+    m = g.find(m);
+    if (m == zero) {
+      return zero; // 0 · x = x · 0 = 0
+    }
+    if (m == one) {
+      continue; // 1 · x = x · 1 = x
+    }
+    kept.push_back(m);
+  }
+  if (kept.empty()) {
+    return one;
+  }
+  if (kept.size() == 1) {
+    return kept.front();
+  }
+  return g.add(makeSeq(std::move(kept)));
+}
+
+// Build a canonical STAR (*) e-class from body `sub`.
+inline Id star(Graph &g, Id sub) {
+  sub = g.find(sub);
+  const PathLang &n = g[sub].nodes.front();
+  if (isStar(n)) {
+    return sub; // (A*)* = A*
+  }
+  if (isZero(n) || isOne(n)) {
+    return oneId(g); // 0* = 1* = 1
+  }
+  return g.add(makeStar(sub));
+}
+
+} // namespace canon
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_CANONICAL_H_

--- a/include/Dataflow/APA/EAN/CostFn.h
+++ b/include/Dataflow/APA/EAN/CostFn.h
@@ -1,0 +1,46 @@
+#ifndef DATAFLOW_APA_EAN_COSTFN_H_
+#define DATAFLOW_APA_EAN_COSTFN_H_
+
+// PathCostFn: an egg-compatible cost function turning CostModel's per-operator
+// weights into a per-e-class best node/cost (the "profiled tree cost"). Split
+// from CostModel.h so that the plain CostModel struct can live in Core's
+// EliminationOptions without dragging egg's Extract.h into Core.
+
+#include "Dataflow/APA/EAN/CostModel.h"
+#include "Dataflow/APA/EAN/PathLang.h"
+#include "Solvers/EGraph/Extract.h"
+
+namespace elimination {
+namespace ean {
+
+struct PathCostFn
+    : ::lotus::egraph::CostFunction<PathCostFn, PathLang, double> {
+  using Cost = double;
+
+  CostModel model;
+
+  PathCostFn() = default;
+  explicit PathCostFn(CostModel m) : model(m) {}
+
+  double opWeight(const PathLang &n) const {
+    if (isZero(n)) return model.wZero;
+    if (isOne(n)) return model.wOne;
+    if (isAtom(n)) return model.wAtom;
+    if (isStar(n)) return model.wStar;
+    if (isJoin(n)) return model.wJoin;
+    return model.wSeq; // seq
+  }
+
+  template <typename C> double cost(const PathLang &node, C &&child_cost) {
+    double total = opWeight(node);
+    for (Id child : node.children()) {
+      total += child_cost(child);
+    }
+    return total;
+  }
+};
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_COSTFN_H_

--- a/include/Dataflow/APA/EAN/CostModel.h
+++ b/include/Dataflow/APA/EAN/CostModel.h
@@ -1,0 +1,61 @@
+#ifndef DATAFLOW_APA_EAN_COSTMODEL_H_
+#define DATAFLOW_APA_EAN_COSTMODEL_H_
+
+// CostModel: per-operator weights (paper §III.D) plus the Eq. 5 shared-DAG
+// objective weights. This is plain data with NO e-graph/egg dependency, so it
+// can be embedded in EliminationOptions (Core) without pulling egg headers into
+// Core. The egg-facing cost function that uses these weights is PathCostFn,
+// defined in CostFn.h.
+
+namespace elimination {
+namespace ean {
+
+struct CostModel {
+  double wJoin = 1.0; // ⊕   (per-operator weights w_o = the operator term)
+  double wSeq = 1.0;  // ·
+  double wStar = 1.0; // *
+  double wAtom = 1.0;
+  double wZero = 0.0;
+  double wOne = 0.0;
+
+  // Eq. 5 shared-DAG objective weights (used by the reuse-aware extractor):
+  //   C_DAG = alpha*N_unique + beta*E_unique + sum_o w_o*N_o + gamma*C_repeat.
+  double alpha = 1.0; // unique DAG nodes (retained memory)
+  double beta = 0.0;  // unique DAG edges (factory construction)
+  double gamma = 0.0; // repeated work under a non-memoizing interpreter
+
+  // Uniform structural weights (approximates unique-node count).
+  static CostModel uniform() { return CostModel{}; }
+
+  // A composition/closure-heavy profile: star > seq > join.
+  static CostModel profiled() {
+    CostModel m;
+    m.wStar = 4.0;
+    m.wSeq = 2.0;
+    m.wJoin = 1.0;
+    m.wAtom = 1.0;
+    m.wZero = 0.0;
+    m.wOne = 0.0;
+    return m;
+  }
+
+  // Shared-DAG objective (Eq. 5) that scores by unique nodes AND edges, so the
+  // reuse-aware extractor minimizes the *exported* factory node count (which
+  // tracks variadic-child edges after re-binarization) rather than just the
+  // e-class count. Candidate generation is unchanged (per-op weight 1); only the
+  // scoring changes, biasing selection toward the fewest-edge equivalent form.
+  static CostModel dag() {
+    CostModel m;
+    m.wJoin = m.wSeq = m.wStar = m.wAtom = 1.0;
+    m.wZero = m.wOne = 0.0;
+    m.alpha = 1.0; // unique DAG nodes
+    m.beta = 1.0;  // unique DAG edges (≈ exported factory nodes)
+    m.gamma = 0.0; // retained-size objective, not interpreter repeat cost
+    return m;
+  }
+};
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_COSTMODEL_H_

--- a/include/Dataflow/APA/EAN/DagStats.h
+++ b/include/Dataflow/APA/EAN/DagStats.h
@@ -1,0 +1,131 @@
+#ifndef DATAFLOW_APA_EAN_DAGSTATS_H_
+#define DATAFLOW_APA_EAN_DAGSTATS_H_
+
+// Structural statistics of a hash-consed path-expression DAG (a batch of
+// PathExprFactory roots), for the EAN evaluation (paper Table VI). All measures
+// are computed over the set of nodes reachable from the given roots.
+//
+//   uniqueNodes  – distinct hash-consed nodes (retained memory proxy)
+//   uniqueEdges  – child links summed over unique nodes (factory construction)
+//   unions/concats/stars/atoms/zeros/ones – unique-node counts by kind
+//   expandedTree – occurrence multiplicity summed over roots (tree size)
+//   maxDepth     – longest root-to-leaf path
+//   sharing()    – expandedTree / uniqueNodes (how much hash-consing folds)
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "Dataflow/APA/Core/PathExpr.h"
+
+namespace elimination {
+namespace ean {
+
+struct DagStats {
+  std::size_t uniqueNodes = 0;
+  std::size_t uniqueEdges = 0;
+  std::size_t unions = 0;
+  std::size_t concats = 0;
+  std::size_t stars = 0;
+  std::size_t atoms = 0;
+  std::size_t zeros = 0;
+  std::size_t ones = 0;
+  double expandedTree = 0.0;
+  std::size_t maxDepth = 0;
+
+  double sharing() const {
+    return uniqueNodes ? expandedTree / static_cast<double>(uniqueNodes) : 0.0;
+  }
+};
+
+template <typename TransferT>
+DagStats computeDagStats(
+    const std::vector<typename PathExprFactory<TransferT>::Ref> &roots) {
+  using Factory = PathExprFactory<TransferT>;
+  using Expr = typename Factory::Expr;
+  using Kind = typename Factory::Kind;
+
+  DagStats st;
+  std::unordered_set<const Expr *> seen;
+  std::vector<const Expr *> post; // post-order (children before parents)
+  std::unordered_map<const Expr *, std::size_t> depth;
+
+  std::function<void(const Expr *)> dfs = [&](const Expr *e) {
+    if (!e || !seen.insert(e).second) {
+      return;
+    }
+    std::size_t childEdges = 0;
+    std::size_t childDepth = 0;
+    auto visit = [&](const Expr *c) {
+      if (c) {
+        ++childEdges;
+        dfs(c);
+        childDepth = std::max(childDepth, depth[c]);
+      }
+    };
+    switch (e->K) {
+    case Kind::Zero: ++st.zeros; break;
+    case Kind::One: ++st.ones; break;
+    case Kind::Atom: ++st.atoms; break;
+    case Kind::Union: ++st.unions; visit(e->L.get()); visit(e->R.get()); break;
+    case Kind::Concat: ++st.concats; visit(e->L.get()); visit(e->R.get()); break;
+    case Kind::Star: ++st.stars; visit(e->L.get()); break;
+    }
+    st.uniqueEdges += childEdges;
+    depth[e] = 1 + childDepth;
+    post.push_back(e);
+  };
+  for (const auto &r : roots) {
+    dfs(r.get());
+  }
+
+  st.uniqueNodes = post.size();
+  for (const auto &r : roots) {
+    if (r) {
+      st.maxDepth = std::max(st.maxDepth, depth[r.get()]);
+    }
+  }
+
+  // Expanded tree size = sum of occurrence multiplicities (top-down path counts;
+  // reverse post-order = parents before children).
+  std::unordered_map<const Expr *, double> mult;
+  for (const auto &r : roots) {
+    if (r) {
+      mult[r.get()] += 1.0;
+    }
+  }
+  for (auto it = post.rbegin(); it != post.rend(); ++it) {
+    const Expr *e = *it;
+    const double m = mult.count(e) ? mult[e] : 0.0;
+    auto push = [&](const Expr *c) {
+      if (c) {
+        mult[c] += m;
+      }
+    };
+    switch (e->K) {
+    case Kind::Union:
+    case Kind::Concat:
+      push(e->L.get());
+      push(e->R.get());
+      break;
+    case Kind::Star:
+      push(e->L.get());
+      break;
+    default:
+      break;
+    }
+  }
+  for (const Expr *e : post) {
+    st.expandedTree += mult.count(e) ? mult[e] : 0.0;
+  }
+
+  return st;
+}
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_DAGSTATS_H_

--- a/include/Dataflow/APA/EAN/EAN.h
+++ b/include/Dataflow/APA/EAN/EAN.h
@@ -1,0 +1,95 @@
+#ifndef DATAFLOW_APA_EAN_EAN_H_
+#define DATAFLOW_APA_EAN_EAN_H_
+
+// EAN top-level entry point: the compiler-style optimizer pass between
+// path-expression construction and interpretation.
+//
+//   ean(R, L, C, B, F, stats, opts) : import R into a canonical e-graph, run
+//   guarded/budgeted saturation, extract the cheapest equivalent shared DAG
+//   under cost model C (reuse-aware, Eq. 5), and export it back into factory F
+//   — one Ref per input root.
+//
+// Fail-safe (paper §III.D, requirement R2 / termination): if anything throws or
+// the result shape is wrong, EAN returns the original root batch R unchanged.
+// By root preservation (I3) this fallback is always available and never worse
+// than the input for analysis semantics. An incorrect client law profile is a
+// client bug and remains outside this guarantee.
+
+#include <vector>
+
+#include "Dataflow/APA/Core/PathExpr.h"
+#include "Dataflow/APA/EAN/BatchExtract.h"
+#include "Dataflow/APA/EAN/Budget.h"
+#include "Dataflow/APA/EAN/CostFn.h"
+#include "Dataflow/APA/EAN/CostModel.h"
+#include "Dataflow/APA/EAN/DagStats.h"
+#include "Dataflow/APA/EAN/Export.h"
+#include "Dataflow/APA/EAN/ExtractOptions.h"
+#include "Dataflow/APA/EAN/Import.h"
+#include "Dataflow/APA/EAN/LawProfile.h"
+#include "Dataflow/APA/EAN/Saturate.h"
+
+namespace elimination {
+namespace ean {
+
+template <typename TransferT>
+std::vector<typename PathExprFactory<TransferT>::Ref>
+ean(const std::vector<typename PathExprFactory<TransferT>::Ref> &R,
+    const LawProfile &L, const CostModel &C, const Budget &B,
+    PathExprFactory<TransferT> &F, SaturationStats *stats = nullptr,
+    ExtractOptions opts = {}) {
+  // Invocation gate: below the raw-node threshold, saturation cannot repay its
+  // overhead — return the input verbatim (root preservation, I3).
+  if (opts.gateMinNodes > 0 &&
+      computeDagStats<TransferT>(R).uniqueNodes < opts.gateMinNodes) {
+    return R;
+  }
+  try {
+    auto imp = importCanonical<TransferT>(R);
+
+    // Plateau signal: cheap tree cost (M3) or the full reuse-aware Eq. 5 cost,
+    // switchable via opts.plateauMode.
+    PathCostFn tree_fn(C);
+    SaturationStats st;
+    if (opts.plateauMode == ExtractOptions::PlateauCost::Dag) {
+      st = saturate(imp.g, imp.roots, L, B, opts,
+                    [&](Graph &g, const std::vector<Id> &roots) {
+                      return reuseAwareCost(g, roots, C, opts);
+                    });
+    } else {
+      st = saturate(imp.g, imp.roots, L, B, opts,
+                    [&](Graph &g, const std::vector<Id> &roots) {
+                      return extractCost(g, roots, tree_fn);
+                    });
+    }
+    if (stats) {
+      *stats = st;
+    }
+
+    // Final export: reuse-aware best selection from the (grown) e-graph.
+    ExtractResult sel = reuseAwareExtract(imp.g, imp.roots, C, opts);
+    PickFn pick = [&sel, &imp](Id c) -> const PathLang & {
+      return sel.chosen.at(imp.g.find(c).value());
+    };
+
+    auto out = exportBatch<TransferT>(imp, F, pick);
+    if (out.size() != R.size()) {
+      return R; // shape mismatch: fall back
+    }
+    // Monotone guard: never return a batch larger than the input (I3 extended
+    // to output quality). Keeps EAN from degrading an already-compact input.
+    if (opts.monotoneGuard &&
+        computeDagStats<TransferT>(out).uniqueNodes >
+            computeDagStats<TransferT>(R).uniqueNodes) {
+      return R;
+    }
+    return out;
+  } catch (...) {
+    return R; // resource/internal failure: fall back to the original batch
+  }
+}
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_EAN_H_

--- a/include/Dataflow/APA/EAN/Expand.h
+++ b/include/Dataflow/APA/EAN/Expand.h
@@ -1,0 +1,207 @@
+#ifndef DATAFLOW_APA_EAN_EXPAND_H_
+#define DATAFLOW_APA_EAN_EXPAND_H_
+
+// Expand: guarded expansion — the Explore-phase primitive (paper §III.C,
+// Table III). It is the REVERSE of factorization: distribute a JOIN that sits
+// inside a SEQ so a shared sub-product can be exposed and reused,
+//
+//     P·(r1 ⊕ … ⊕ rk)·S   =   (P·r1·S) ⊕ … ⊕ (P·rk·S)
+//
+// added as an equivalent representation of the SEQ's e-class (the original is
+// retained; extraction chooses). Because expansion is the inverse of the Factor
+// phase it can, unguarded, undo factorization or explode the e-graph. It is
+// therefore admitted only under an OPPORTUNITY GUARD: at least
+// `expandMinAligned` of the produced branches P·rm·S must ALREADY exist as
+// e-classes (i.e. the expansion aligns with structure already present, so it
+// exposes real sharing rather than inventing new terms), and the expansion adds
+// at most `expandGrowthCap` new e-nodes. Expansion at a trailing JOIN (P·(⊕r))
+// uses left distributivity; at a leading JOIN ((⊕r)·S) it uses right
+// distributivity; a JOIN in the middle needs both — the same law gating as
+// factorization, so soundness is inherited.
+//
+// Termination: both forms are retained and hash-consed, so re-expanding an
+// existing form is a uniteChecked no-op, and a Factor/Explore alternation
+// converges (the reversed form already exists); the round/e-node budget is the
+// backstop. Two phases (scan read-only, then materialize) mirror Factorize.
+
+#include <cstddef>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "Dataflow/APA/EAN/Canonical.h"
+#include "Dataflow/APA/EAN/ExtractOptions.h"
+#include "Dataflow/APA/EAN/LawProfile.h"
+#include "Dataflow/APA/EAN/PathLang.h"
+
+namespace elimination {
+namespace ean {
+namespace detail {
+
+// Append `id`'s SEQ elements (flattened one level) to `out`, or `id` itself when
+// its class is not a sequence. Mirrors the flattened form the original
+// (pre-factorization) sequence had, so a reversed factorization aligns with it.
+inline void appendClassElems(Graph &g, Id id, std::vector<Id> &out) {
+  const Id c = g.find(id);
+  for (const PathLang &n : g[c].nodes) {
+    if (isSeq(n)) {
+      for (Id e : n.children()) {
+        out.push_back(g.find(e));
+      }
+      return;
+    }
+  }
+  out.push_back(c);
+}
+
+// If class `c` contains a JOIN e-node, copy its (canonicalized) member ids into
+// `out` and return true (first join node wins).
+inline bool joinMembers(Graph &g, Id c, std::vector<Id> &out) {
+  for (const PathLang &n : g[c].nodes) {
+    if (isJoin(n)) {
+      out.clear();
+      out.reserve(n.children().size());
+      for (Id m : n.children()) {
+        out.push_back(g.find(m));
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+// Read-only mirror of canon::seq: the canonical e-class id of the sequence over
+// `elems` IF it already exists, else nullopt. `elems` must be canonical
+// (find'd) and flattened. Never mutates the e-graph.
+inline std::optional<Id> lookupCanonSeq(const Graph &g,
+                                        const std::vector<Id> &elems) {
+  const auto zeroOpt = g.lookup(makeZero());
+  const auto oneOpt = g.lookup(makeOne());
+  std::vector<Id> kept;
+  kept.reserve(elems.size());
+  for (Id m : elems) {
+    const Id mc = g.find(m);
+    if (zeroOpt && mc == *zeroOpt) {
+      return zeroOpt; // 0 · x = 0
+    }
+    if (oneOpt && mc == *oneOpt) {
+      continue; // drop 1
+    }
+    kept.push_back(mc);
+  }
+  if (kept.empty()) {
+    return oneOpt;
+  }
+  if (kept.size() == 1) {
+    return kept.front();
+  }
+  return g.lookup(makeSeq(kept));
+}
+
+// A recorded expansion opportunity (a JOIN element inside a SEQ), already passed
+// through the law gate and the alignment/growth guard.
+struct ExpandAction {
+  Id classId;              // the SEQ e-class gaining an alternative
+  std::vector<Id> prefix;  // elems before the JOIN
+  std::vector<Id> branches; // the JOIN's member classes
+  std::vector<Id> suffix;  // elems after the JOIN
+};
+
+} // namespace detail
+
+// One round of guarded expansion over the whole e-graph. Returns the number of
+// e-classes that gained a genuinely new representation.
+inline std::size_t expandRound(Graph &g, const LawProfile &L,
+                               const ExtractOptions &opts) {
+  const bool hasLeft = L.has(Law::LeftDistributive);
+  const bool hasRight = L.has(Law::RightDistributive);
+  if (!hasLeft && !hasRight) {
+    return 0;
+  }
+
+  // Phase A: scan (read-only). Collect admitted expansion actions.
+  std::vector<detail::ExpandAction> actions;
+  for (Id c0 : g.classIds()) {
+    const Id c = g.find(c0);
+    for (const PathLang &node : g[c].nodes) {
+      if (!isSeq(node)) {
+        continue;
+      }
+      std::vector<Id> elems;
+      elems.reserve(node.children().size());
+      for (Id e : node.children()) {
+        elems.push_back(g.find(e));
+      }
+      for (std::size_t i = 0; i < elems.size(); ++i) {
+        std::vector<Id> branches;
+        if (!detail::joinMembers(g, elems[i], branches)) {
+          continue; // element i is not a JOIN
+        }
+        const bool hasPrefix = i > 0;
+        const bool hasSuffix = i + 1 < elems.size();
+        // Law gate: pulling a prefix into the join needs left distributivity;
+        // pulling a suffix in needs right distributivity.
+        if (hasPrefix && !hasLeft) {
+          continue;
+        }
+        if (hasSuffix && !hasRight) {
+          continue;
+        }
+
+        std::vector<Id> prefix(elems.begin(), elems.begin() + i);
+        std::vector<Id> suffix(elems.begin() + i + 1, elems.end());
+
+        // Opportunity guard: count branches whose expanded product already
+        // exists (alignment), and the new e-nodes the expansion would add.
+        std::size_t aligned = 0;
+        std::size_t newNodes = 1; // the produced JOIN itself
+        for (Id rm : branches) {
+          std::vector<Id> flat = prefix;
+          detail::appendClassElems(g, rm, flat);
+          flat.insert(flat.end(), suffix.begin(), suffix.end());
+          if (detail::lookupCanonSeq(g, flat)) {
+            ++aligned;
+          } else {
+            ++newNodes;
+          }
+        }
+        if (aligned < opts.expandMinAligned || newNodes > opts.expandGrowthCap) {
+          continue;
+        }
+
+        detail::ExpandAction a;
+        a.classId = c;
+        a.prefix = std::move(prefix);
+        a.branches = std::move(branches);
+        a.suffix = std::move(suffix);
+        actions.push_back(std::move(a));
+      }
+    }
+  }
+
+  // Phase B: materialize the expanded (distributed) join and unite it in.
+  std::size_t changes = 0;
+  for (auto &a : actions) {
+    std::vector<Id> branchSeqs;
+    branchSeqs.reserve(a.branches.size());
+    for (Id rm : a.branches) {
+      std::vector<Id> flat = a.prefix;
+      detail::appendClassElems(g, rm, flat);
+      flat.insert(flat.end(), a.suffix.begin(), a.suffix.end());
+      branchSeqs.push_back(canon::seq(g, std::move(flat)));
+    }
+    const Id newJoin = canon::join(g, std::move(branchSeqs));
+    if (g.uniteChecked(a.classId, newJoin).second) {
+      ++changes;
+    }
+  }
+
+  // canon::* dirties the e-graph even on memo hits; restore clean state.
+  g.rebuild();
+  return changes;
+}
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_EXPAND_H_

--- a/include/Dataflow/APA/EAN/Export.h
+++ b/include/Dataflow/APA/EAN/Export.h
@@ -1,0 +1,128 @@
+#ifndef DATAFLOW_APA_EAN_EXPORT_H_
+#define DATAFLOW_APA_EAN_EXPORT_H_
+
+// Export: canonical e-graph  ->  PathExprFactory<TransferT>::Ref.
+//
+// Node selection per e-class is the `pick` callback. It defaults to
+// `nodes.front()` (fine when a class has a single e-node, e.g. right after
+// import). Once saturation adds competing forms, the caller supplies a
+// cost-driven pick (e.g. egg Extractor::findBestNode) so export materializes
+// the cheapest representative. The recursive rebuild and the shared-node memo
+// are independent of the pick.
+//
+// Cross-root sharing is recovered automatically: `memo_` keyed by canonical Id
+// ensures each e-class is materialized once, and PathExprFactory's own
+// hash-consing (unite/concat/star caches) collapses structurally equal nodes.
+// Atoms are re-exported by reusing their original Ref verbatim (opaque to EAN).
+
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+#include "Dataflow/APA/Core/PathExpr.h"
+#include "Dataflow/APA/EAN/AtomTable.h"
+#include "Dataflow/APA/EAN/Import.h" // for the Graph type alias
+#include "Dataflow/APA/EAN/PathLang.h"
+
+namespace elimination {
+namespace ean {
+
+// Chooses which e-node represents a class during export. Returns a reference
+// valid for the duration of the export call.
+using PickFn = std::function<const PathLang &(Id)>;
+
+namespace detail {
+
+template <typename TransferT> class Exporter {
+public:
+  using Factory = PathExprFactory<TransferT>;
+  using Ref = typename Factory::Ref;
+
+  Exporter(const Graph &g, const AtomTable<TransferT> &atoms, Factory &f,
+           PickFn pick = {})
+      : g_(g), atoms_(atoms), f_(f), pick_(std::move(pick)) {}
+
+  Ref exportId(Id c) {
+    c = g_.find(c);
+    auto it = memo_.find(c);
+    if (it != memo_.end()) {
+      return it->second;
+    }
+    Ref result = build(pick(c));
+    memo_.emplace(c, result);
+    return result;
+  }
+
+private:
+  const PathLang &pick(Id c) {
+    return pick_ ? pick_(c) : g_[c].nodes.front();
+  }
+
+  Ref build(const PathLang &n) {
+    if (isZero(n)) {
+      return f_.zero();
+    }
+    if (isOne(n)) {
+      return f_.one();
+    }
+    if (isAtom(n)) {
+      return atoms_.atom(parseAtomId(n));
+    }
+    if (isStar(n)) {
+      return f_.star(exportId(n.children().front()));
+    }
+    if (isJoin(n)) {
+      const auto &kids = n.children();
+      Ref acc = exportId(kids.front());
+      for (std::size_t i = 1; i < kids.size(); ++i) {
+        acc = f_.unite(acc, exportId(kids[i]));
+      }
+      return acc;
+    }
+    // isSeq
+    const auto &kids = n.children();
+    Ref acc = exportId(kids.front());
+    for (std::size_t i = 1; i < kids.size(); ++i) {
+      acc = f_.concat(acc, exportId(kids[i]));
+    }
+    return acc;
+  }
+
+  const Graph &g_;
+  const AtomTable<TransferT> &atoms_;
+  Factory &f_;
+  PickFn pick_;
+  std::unordered_map<Id, Ref> memo_;
+};
+
+} // namespace detail
+
+// Export one e-class `root` back into factory `F`, returning an equivalent
+// path-expression Ref. `pick` defaults to nodes.front().
+template <typename TransferT>
+typename PathExprFactory<TransferT>::Ref
+exportTree(const Graph &g, const AtomTable<TransferT> &atoms, Id root,
+           PathExprFactory<TransferT> &F, PickFn pick = {}) {
+  detail::Exporter<TransferT> exp(g, atoms, F, std::move(pick));
+  return exp.exportId(root);
+}
+
+// Batch convenience: export every root of an ImportResult into `F`, preserving
+// cross-root sharing within a single Exporter (one shared memo).
+template <typename TransferT>
+std::vector<typename PathExprFactory<TransferT>::Ref>
+exportBatch(const ImportResult<TransferT> &imp, PathExprFactory<TransferT> &F,
+            PickFn pick = {}) {
+  detail::Exporter<TransferT> exp(imp.g, imp.atoms, F, std::move(pick));
+  std::vector<typename PathExprFactory<TransferT>::Ref> out;
+  out.reserve(imp.roots.size());
+  for (Id r : imp.roots) {
+    out.push_back(exp.exportId(r));
+  }
+  return out;
+}
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_EXPORT_H_

--- a/include/Dataflow/APA/EAN/ExtractOptions.h
+++ b/include/Dataflow/APA/EAN/ExtractOptions.h
@@ -1,0 +1,56 @@
+#ifndef DATAFLOW_APA_EAN_EXTRACTOPTIONS_H_
+#define DATAFLOW_APA_EAN_EXTRACTOPTIONS_H_
+
+// Knobs for reuse-aware batch extraction (paper Algorithm 2) and for how the
+// saturation driver measures its plateau signal.
+
+#include <cstddef>
+
+namespace elimination {
+namespace ean {
+
+struct ExtractOptions {
+  std::size_t reuseIters = 3;   // K: reuse-refinement iterations
+  double discountLambda = 0.5;  // λ: sublinear sharing discount rate
+  std::size_t relaxPasses = 0;  // cycle-safe relaxation passes; 0 = auto (#classes+1)
+
+  // Which cost the saturation loop uses to detect a plateau. Tree is cheap
+  // (M3 egg tree cost); Dag runs the full reuse-aware Eq. 5 objective each
+  // round (faithful to Algorithm 1, but K·I× more expensive). Switchable so the
+  // choice can be made from evaluation data (RQ4).
+  enum class PlateauCost { Tree, Dag };
+  PlateauCost plateauMode = PlateauCost::Tree;
+
+  // Invocation gate (paper §IV-C): skip EAN entirely when the raw batch has
+  // fewer than this many unique DAG nodes (0 = no gate). Below the threshold
+  // saturation cannot repay its overhead, so ean() returns the input verbatim.
+  std::size_t gateMinNodes = 0;
+
+  // Monotone guard: if the exported batch has MORE unique nodes than the input,
+  // return the input verbatim. Extends I3 (root preservation) to output-quality
+  // preservation, so EAN never degrades an already-compact input (e.g. one
+  // produced by cost-aware elimination ordering). Off by default.
+  bool monotoneGuard = false;
+
+  // Explore phase — guarded expansion (paper §III.C, Table III). Distributes a
+  // JOIN sitting inside a SEQ (the reverse of factorization) to expose sharing:
+  //   P·(r1 ⊕ … ⊕ rk)·S  ->  (P·r1·S) ⊕ … ⊕ (P·rk·S)
+  // Admitted only when it aligns with structure already in the e-graph — at
+  // least `expandMinAligned` produced branches must ALREADY exist as e-classes
+  // (0 disables the alignment requirement) — and it adds at most
+  // `expandGrowthCap` new e-nodes to the class. This opportunity guard keeps
+  // expansion from blindly undoing factorization or exploding the e-graph.
+  std::size_t expandMinAligned = 1;
+  std::size_t expandGrowthCap = 64;
+
+  // Phase scheduling. true (default) runs the phases Cleanup→Factor→Star→Explore
+  // in order, each to local saturation before advancing (paper Algorithm 1).
+  // false applies every rewrite family together each round (the "No phase
+  // schedule" ablation for Table VIII / RQ4).
+  bool scheduled = true;
+};
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_EXTRACTOPTIONS_H_

--- a/include/Dataflow/APA/EAN/Factorize.h
+++ b/include/Dataflow/APA/EAN/Factorize.h
@@ -1,0 +1,271 @@
+#ifndef DATAFLOW_APA_EAN_FACTORIZE_H_
+#define DATAFLOW_APA_EAN_FACTORIZE_H_
+
+// Factorize: variadic prefix/suffix factorization over JOIN e-classes
+// (paper §III.B.b; Table I left/right distributivity). This is the FACTOR-phase
+// primitive; the saturation loop that schedules it lives in M3.
+//
+// Binary distributivity rules cannot express factorization once choice and
+// sequence are variadic (e.g. a JOIN holding a·b·c, a·b·d, x). So this is a
+// direct e-graph pass rather than a string-pattern rewrite: for each JOIN
+// e-class it groups the SEQ members by their first (prefix) / last (suffix)
+// element e-class, extends each group to its longest common prefix/suffix P,
+// and adds
+//     JOIN( P·(r1 ⊕ … ⊕ rk),  <non-participating members…> )
+// as an equivalent representation of the whole class (partial grouping keeps
+// members that don't share the factor). The dual holds for suffixes:
+//     JOIN( (r1 ⊕ … ⊕ rk)·P,  <non-participating members…> ).
+//
+// The original JOIN e-node is NOT removed — equality saturation retains both
+// forms; extraction (M4) later chooses. Nesting (residual joins that factor
+// again) is produced by repeated rounds.
+//
+// Correctness gating: prefix requires Law::LeftDistributive, suffix requires
+// Law::RightDistributive.
+//
+// Two phases avoid mutating the e-graph while scanning it: Phase A only reads
+// (collects factoring "ingredients" as plain Id lists); Phase B builds nodes
+// (canon::*) and unites. factorizeRound rebuilds at the end and returns the
+// number of classes that actually gained a new representation, so a caller can
+// iterate to a fixpoint.
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "Dataflow/APA/EAN/Canonical.h"
+#include "Dataflow/APA/EAN/LawProfile.h"
+#include "Dataflow/APA/EAN/PathLang.h"
+
+namespace elimination {
+namespace ean {
+namespace detail {
+
+// If `member`'s e-class contains a SEQ e-node, copy its (canonicalized) element
+// ids into `out` and return true. SEQ nodes always have >= 2 elements (canon
+// collapses shorter ones), so a SEQ member has a well-defined first and last.
+inline bool seqElems(Graph &g, Id member, std::vector<Id> &out) {
+  const auto &cls = g[member];
+  for (const PathLang &n : cls.nodes) {
+    if (isSeq(n)) {
+      out.clear();
+      out.reserve(n.children().size());
+      for (Id e : n.children()) {
+        out.push_back(g.find(e));
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+// A recorded factoring opportunity, resolved into concrete e-nodes in Phase B.
+struct FactorAction {
+  Id classId;                            // the JOIN e-class to add a form to
+  bool prefix;                           // true: P·(⊕r);  false: (⊕r)·P
+  std::vector<Id> fixedSide;             // the shared factor P (in order)
+  std::vector<std::vector<Id>> residuals; // varying part per participating member
+  std::vector<Id> passthrough;           // non-participating members, kept as-is
+};
+
+inline void scanPrefix(Id classId, const std::vector<Id> &members,
+                       const std::vector<char> &isSeqMember,
+                       const std::vector<std::vector<Id>> &elems,
+                       std::vector<FactorAction> &out) {
+  std::unordered_map<std::uint32_t, std::vector<std::size_t>> groups;
+  for (std::size_t i = 0; i < members.size(); ++i) {
+    if (isSeqMember[i]) {
+      groups[elems[i].front().value()].push_back(i);
+    }
+  }
+  for (auto &kv : groups) {
+    const auto &idxs = kv.second;
+    if (idxs.size() < 2) {
+      continue;
+    }
+    std::size_t minLen = SIZE_MAX;
+    for (std::size_t i : idxs) {
+      minLen = std::min(minLen, elems[i].size());
+    }
+    std::size_t lcp = 0; // longest common prefix length (>= 1, shared first elem)
+    for (; lcp < minLen; ++lcp) {
+      Id ref = elems[idxs[0]][lcp];
+      bool allEq = true;
+      for (std::size_t i : idxs) {
+        if (!(elems[i][lcp] == ref)) {
+          allEq = false;
+          break;
+        }
+      }
+      if (!allEq) {
+        break;
+      }
+    }
+    FactorAction a;
+    a.classId = classId;
+    a.prefix = true;
+    a.fixedSide.assign(elems[idxs[0]].begin(), elems[idxs[0]].begin() + lcp);
+    std::vector<char> inGroup(members.size(), 0);
+    for (std::size_t i : idxs) {
+      inGroup[i] = 1;
+      a.residuals.emplace_back(elems[i].begin() + lcp, elems[i].end());
+    }
+    for (std::size_t i = 0; i < members.size(); ++i) {
+      if (!inGroup[i]) {
+        a.passthrough.push_back(members[i]);
+      }
+    }
+    out.push_back(std::move(a));
+  }
+}
+
+inline void scanSuffix(Id classId, const std::vector<Id> &members,
+                       const std::vector<char> &isSeqMember,
+                       const std::vector<std::vector<Id>> &elems,
+                       std::vector<FactorAction> &out) {
+  std::unordered_map<std::uint32_t, std::vector<std::size_t>> groups;
+  for (std::size_t i = 0; i < members.size(); ++i) {
+    if (isSeqMember[i]) {
+      groups[elems[i].back().value()].push_back(i);
+    }
+  }
+  for (auto &kv : groups) {
+    const auto &idxs = kv.second;
+    if (idxs.size() < 2) {
+      continue;
+    }
+    std::size_t minLen = SIZE_MAX;
+    for (std::size_t i : idxs) {
+      minLen = std::min(minLen, elems[i].size());
+    }
+    std::size_t lcs = 0; // longest common suffix length (>= 1, shared last elem)
+    for (; lcs < minLen; ++lcs) {
+      Id ref = elems[idxs[0]][elems[idxs[0]].size() - 1 - lcs];
+      bool allEq = true;
+      for (std::size_t i : idxs) {
+        if (!(elems[i][elems[i].size() - 1 - lcs] == ref)) {
+          allEq = false;
+          break;
+        }
+      }
+      if (!allEq) {
+        break;
+      }
+    }
+    FactorAction a;
+    a.classId = classId;
+    a.prefix = false;
+    const auto &sample = elems[idxs[0]];
+    a.fixedSide.assign(sample.end() - lcs, sample.end());
+    std::vector<char> inGroup(members.size(), 0);
+    for (std::size_t i : idxs) {
+      inGroup[i] = 1;
+      a.residuals.emplace_back(elems[i].begin(), elems[i].end() - lcs);
+    }
+    for (std::size_t i = 0; i < members.size(); ++i) {
+      if (!inGroup[i]) {
+        a.passthrough.push_back(members[i]);
+      }
+    }
+    out.push_back(std::move(a));
+  }
+}
+
+} // namespace detail
+
+// Run one round of prefix/suffix factorization over the whole e-graph.
+// Returns the number of e-classes that gained a genuinely new representation.
+inline std::size_t factorizeRound(Graph &g, const LawProfile &L) {
+  const bool doPrefix = L.has(Law::LeftDistributive);
+  const bool doSuffix = L.has(Law::RightDistributive);
+  if (!doPrefix && !doSuffix) {
+    return 0;
+  }
+
+  // Phase A: scan (read-only w.r.t. e-graph structure — no add / no unite).
+  std::vector<detail::FactorAction> actions;
+  for (Id c : g.classIds()) {
+    c = g.find(c);
+    const auto &cls = g[c];
+    for (const PathLang &node : cls.nodes) {
+      if (!isJoin(node)) {
+        continue;
+      }
+      std::vector<Id> members;
+      members.reserve(node.children().size());
+      for (Id m : node.children()) {
+        members.push_back(g.find(m));
+      }
+      std::vector<char> isSeqM(members.size(), 0);
+      std::vector<std::vector<Id>> elems(members.size());
+      for (std::size_t i = 0; i < members.size(); ++i) {
+        isSeqM[i] = detail::seqElems(g, members[i], elems[i]) ? 1 : 0;
+      }
+      if (doPrefix) {
+        detail::scanPrefix(c, members, isSeqM, elems, actions);
+      }
+      if (doSuffix) {
+        detail::scanSuffix(c, members, isSeqM, elems, actions);
+      }
+    }
+  }
+
+  // Phase B: materialize factored forms and unite them into their classes.
+  std::size_t changes = 0;
+  for (auto &a : actions) {
+    std::vector<Id> resids;
+    resids.reserve(a.residuals.size());
+    for (auto &r : a.residuals) {
+      resids.push_back(canon::seq(g, r)); // empty tail/head -> one
+    }
+    const Id residualJoin = canon::join(g, std::move(resids));
+
+    std::vector<Id> factoredElems;
+    if (a.prefix) {
+      factoredElems = a.fixedSide;
+      factoredElems.push_back(residualJoin);
+    } else {
+      factoredElems.push_back(residualJoin);
+      factoredElems.insert(factoredElems.end(), a.fixedSide.begin(),
+                           a.fixedSide.end());
+    }
+    const Id factoredSeq = canon::seq(g, std::move(factoredElems));
+
+    std::vector<Id> newMembers;
+    newMembers.reserve(1 + a.passthrough.size());
+    newMembers.push_back(factoredSeq);
+    for (Id p : a.passthrough) {
+      newMembers.push_back(p);
+    }
+    const Id newJoin = canon::join(g, std::move(newMembers));
+
+    if (g.uniteChecked(a.classId, newJoin).second) {
+      ++changes;
+    }
+  }
+
+  // canon::* uses g.add(), which marks the e-graph dirty even when nothing new
+  // merges, so always restore a clean, queryable state before returning.
+  g.rebuild();
+  return changes;
+}
+
+// Convenience: iterate factorizeRound to a fixpoint (bounded). Returns total
+// rounds that made progress. M3 will replace this with a budgeted scheduler.
+inline std::size_t factorizeToFixpoint(Graph &g, const LawProfile &L,
+                                       std::size_t maxRounds = 64) {
+  std::size_t rounds = 0;
+  for (; rounds < maxRounds; ++rounds) {
+    if (factorizeRound(g, L) == 0) {
+      break;
+    }
+  }
+  return rounds;
+}
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_FACTORIZE_H_

--- a/include/Dataflow/APA/EAN/Greedy.h
+++ b/include/Dataflow/APA/EAN/Greedy.h
@@ -1,0 +1,41 @@
+#ifndef DATAFLOW_APA_EAN_GREEDY_H_
+#define DATAFLOW_APA_EAN_GREEDY_H_
+
+// Greedy: the paper's "Greedy" configuration — Default plus deterministic local
+// simplification. It shares EAN's canonicalization (ACI/associativity
+// normalization via the e-graph import) and its deterministic prefix
+// factorization (left-distributivity, universally sound), but performs a plain
+// per-class cheapest-tree extraction (reuseIters = 0): NO reuse-aware,
+// cross-root cost optimization over retained competing forms. The Greedy→EAN
+// gap therefore isolates exactly the value of retaining alternatives for
+// cost-driven batch extraction.
+//
+// Implemented as the EAN pipeline restricted to {safe-minimal laws, uniform
+// cost, no reuse iterations, monotone guard}. Semantics-preserving: only
+// left-distributive factorization + associativity re-normalization are used, so
+// every client's results are preserved (no distributivity assumption).
+
+#include <vector>
+
+#include "Dataflow/APA/Core/PathExpr.h"
+#include "Dataflow/APA/EAN/EAN.h"
+
+namespace elimination {
+
+// Greedily simplify a batch of path-expression roots in factory `F`, returning
+// one simplified Ref per input root (order preserved). See header comment.
+template <typename TransferT>
+std::vector<typename PathExprFactory<TransferT>::Ref>
+greedySimplify(const std::vector<typename PathExprFactory<TransferT>::Ref> &R,
+               PathExprFactory<TransferT> &F) {
+  ean::ExtractOptions opts;
+  opts.reuseIters = 0;       // no reuse-aware cross-root optimization
+  opts.monotoneGuard = true; // never return a batch larger than the input
+  return ean::ean<TransferT>(R, ean::LawProfile::safeMinimal(),
+                             ean::CostModel::uniform(), ean::Budget::unbounded(),
+                             F, nullptr, opts);
+}
+
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_GREEDY_H_

--- a/include/Dataflow/APA/EAN/Import.h
+++ b/include/Dataflow/APA/EAN/Import.h
@@ -1,0 +1,128 @@
+#ifndef DATAFLOW_APA_EAN_IMPORT_H_
+#define DATAFLOW_APA_EAN_IMPORT_H_
+
+// Import: PathExprFactory<TransferT>::Ref DAG  ->  canonical e-graph.
+//
+// This realizes invariants I1–I3 of the paper's import step (docs, §III.A):
+//   I2 (profile-relative canonical form): variadic joins are flattened, have 0
+//       removed, are deduplicated and sorted; variadic sequences are flattened
+//       and have 1 removed but are NEVER reordered.
+//   I3 (root preservation): every input root maps to an e-class id, returned in
+//       order, so the original expression is always recoverable.
+//
+// Flattening is done on the *Ref tree* (PathExprFactory's Union/Concat are
+// binary, so `(a⊕b)⊕c` is literally `Union(Union(a,b),c)`), which is cleaner
+// than post-hoc flattening inside the e-graph and needs no e-graph state. The
+// per-node canonical form is then produced by the shared canon:: builders.
+
+#include <cstdint>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "Dataflow/APA/Core/PathExpr.h"
+#include "Dataflow/APA/EAN/AtomTable.h"
+#include "Dataflow/APA/EAN/Canonical.h" // Graph + canon::join/seq/star
+#include "Dataflow/APA/EAN/PathLang.h"
+
+namespace elimination {
+namespace ean {
+
+template <typename TransferT> struct ImportResult {
+  Graph g;
+  std::vector<Id> roots;         // one canonical e-class id per input root (I3)
+  AtomTable<TransferT> atoms;    // atom id <-> original Ref, for Export
+};
+
+namespace detail {
+
+template <typename TransferT> class Importer {
+public:
+  using Factory = PathExprFactory<TransferT>;
+  using Ref = typename Factory::Ref;
+  using Kind = typename Factory::Kind;
+
+  Graph g;
+  std::vector<Id> roots;
+  AtomTable<TransferT> atoms;
+
+  Id importExpr(const Ref &e) {
+    auto it = memo_.find(e.get());
+    if (it != memo_.end()) {
+      return g.find(it->second);
+    }
+    Id result = importFresh(e);
+    memo_.emplace(e.get(), result);
+    return result;
+  }
+
+private:
+  Id importFresh(const Ref &e) {
+    switch (e->K) {
+    case Kind::Zero:
+      return canon::zeroId(g);
+    case Kind::One:
+      return canon::oneId(g);
+    case Kind::Atom:
+      return g.add(makeAtom(atoms.intern(e)));
+    case Kind::Union: {
+      std::vector<Id> members;
+      collectJoin(e, members);
+      return canon::join(g, std::move(members));
+    }
+    case Kind::Concat: {
+      std::vector<Id> members;
+      collectSeq(e, members);
+      return canon::seq(g, std::move(members));
+    }
+    case Kind::Star:
+      return canon::star(g, importExpr(e->L));
+    }
+    return canon::zeroId(g); // unreachable; silences -Wreturn-type
+  }
+
+  // Flatten nested Union at the Ref level; leaves (non-Union) get imported.
+  void collectJoin(const Ref &e, std::vector<Id> &out) {
+    if (e->K == Kind::Union) {
+      collectJoin(e->L, out);
+      collectJoin(e->R, out);
+    } else {
+      out.push_back(importExpr(e));
+    }
+  }
+
+  void collectSeq(const Ref &e, std::vector<Id> &out) {
+    if (e->K == Kind::Concat) {
+      collectSeq(e->L, out);
+      collectSeq(e->R, out);
+    } else {
+      out.push_back(importExpr(e));
+    }
+  }
+
+  std::unordered_map<const typename Factory::Expr *, Id> memo_;
+};
+
+} // namespace detail
+
+// Import a batch of path-expression roots into a canonical e-graph.
+template <typename TransferT>
+ImportResult<TransferT>
+importCanonical(const std::vector<typename PathExprFactory<TransferT>::Ref> &R) {
+  detail::Importer<TransferT> imp;
+  imp.roots.reserve(R.size());
+  for (const auto &r : R) {
+    imp.roots.push_back(imp.importExpr(r));
+  }
+  imp.g.rebuild();
+  for (auto &id : imp.roots) {
+    id = imp.g.find(id);
+  }
+  return ImportResult<TransferT>{std::move(imp.g), std::move(imp.roots),
+                                 std::move(imp.atoms)};
+}
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_IMPORT_H_

--- a/include/Dataflow/APA/EAN/LawProfile.h
+++ b/include/Dataflow/APA/EAN/LawProfile.h
@@ -1,0 +1,93 @@
+#ifndef DATAFLOW_APA_EAN_LAWPROFILE_H_
+#define DATAFLOW_APA_EAN_LAWPROFILE_H_
+
+// LawProfile: the client-declared set of algebraic laws EAN is allowed to use
+// when rewriting path expressions (paper §III.B.c, Table I; requirement R1).
+//
+// Only *exploratory* rewrites are gated here. The canonical representation
+// laws (choice ACI, identities, annihilation) are enforced unconditionally by
+// Import/Canonical, matching what the baseline PathExprFactory already does at
+// construction time.
+//
+// A rewrite is enabled only when its required capability is present, so an
+// optimizer for one client never imposes stronger algebraic assumptions on
+// another. Correctness is relative to the client actually satisfying its
+// declared profile (an incorrect declaration is a client bug, outside EAN's
+// proof boundary).
+
+#include <cstdint>
+
+namespace elimination {
+namespace ean {
+
+enum class Law : unsigned {
+  LeftDistributive = 0, // (a·b) ⊕ (a·c) = a·(b ⊕ c)     — prefix factorization
+  RightDistributive,    // (b·a) ⊕ (c·a) = (b ⊕ c)·a     — suffix factorization
+  Annihilation,         // a·0 = 0·a = 0
+  KleeneStar,           // (a*)* = a*, 0* = 1* = 1
+  LeftUnfold,           // a* = 1 ⊕ a·a*
+  RightUnfold,          // a* = 1 ⊕ a*·a
+  Sliding,              // (a·b)*·a = a·(b·a)*
+  Count
+};
+
+class LawProfile {
+public:
+  LawProfile() = default;
+
+  bool has(Law l) const { return (bits_ >> idx(l)) & 1u; }
+  LawProfile &enable(Law l) {
+    bits_ |= (1u << idx(l));
+    return *this;
+  }
+  LawProfile &disable(Law l) {
+    bits_ &= ~(1u << idx(l));
+    return *this;
+  }
+
+  // A full Kleene-algebra client: every law enabled.
+  static LawProfile kleeneAlgebra() {
+    LawProfile p;
+    p.enable(Law::LeftDistributive)
+        .enable(Law::RightDistributive)
+        .enable(Law::Annihilation)
+        .enable(Law::KleeneStar)
+        .enable(Law::LeftUnfold)
+        .enable(Law::RightUnfold)
+        .enable(Law::Sliding);
+    return p;
+  }
+
+  // A weaker flow algebra: distributivity + annihilation, but no star laws.
+  static LawProfile flowAlgebra() {
+    LawProfile p;
+    p.enable(Law::LeftDistributive)
+        .enable(Law::RightDistributive)
+        .enable(Law::Annihilation);
+    return p;
+  }
+
+  static LawProfile none() { return LawProfile(); }
+
+  // The universally-safe minimal profile: LEFT distributivity only. Left
+  // factorization (a·b)⊕(a·c) = a·(b⊕c) holds unconditionally for the
+  // compositional MOP interpretation (the shared prefix is applied once, then
+  // the branches meet), so enabling EAN with this profile can never change any
+  // client's result — including non-distributive clients like constant
+  // propagation. Distributive clients may additionally enable RightDistributive
+  // and the star laws.
+  static LawProfile safeMinimal() {
+    LawProfile p;
+    p.enable(Law::LeftDistributive);
+    return p;
+  }
+
+private:
+  static unsigned idx(Law l) { return static_cast<unsigned>(l); }
+  std::uint32_t bits_ = 0;
+};
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_LAWPROFILE_H_

--- a/include/Dataflow/APA/EAN/PathLang.h
+++ b/include/Dataflow/APA/EAN/PathLang.h
@@ -1,0 +1,225 @@
+#ifndef DATAFLOW_APA_EAN_PATHLANG_H_
+#define DATAFLOW_APA_EAN_PATHLANG_H_
+
+// PathLang: the e-graph-side representation of APA path expressions.
+//
+// This is a TYPED language (egg `define_language!` style): a path-expression
+// e-node is one of a fixed set of kinds, and an atom carries its transfer id as
+// a typed integer payload rather than being encoded into an operator STRING
+// ("atom#<id>") as in the previous SymbolLang-based representation. This removes
+// per-node string allocation/parsing and, crucially, orders atoms NUMERICALLY
+// (atom 2 < atom 10) instead of lexicographically ("atom#10" < "atom#2"), which
+// the extractor's tie-break relies on.
+//
+// Operator kinds (see docs/EAN_项目计划书.md, M1):
+//   Zero  leaf     -- 0  (no path)
+//   One   leaf     -- 1  (empty path)
+//   Atom  leaf     -- opaque transfer atom, id keyed by AtomTable
+//   Join  variadic -- ⊕  (choice);   children sorted + deduped (ACI)
+//   Seq   variadic -- ·  (sequence);  children order-preserving
+//   Star  arity 1  -- *  (iteration)
+//
+// The variadic-vs-canonical rules (flatten / sort / dedup for join, flatten /
+// keep-order for seq) are enforced by Import/Canonical, not here; this header
+// only defines the node type, its Language interface, and named constructors.
+//
+// Downstream code (Canonical/Factorize/Star/Import/Export/AtomTable) uses only
+// the is*/make*/parseAtomId helpers below, so it is agnostic to this typed
+// representation.
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Solvers/EGraph/Id.h"
+#include "Solvers/EGraph/Language.h"
+#include "Solvers/EGraph/Util.h"
+
+namespace elimination {
+namespace ean {
+
+using Id = ::lotus::egraph::Id;
+
+enum class PathKind : std::uint8_t { Zero, One, Atom, Seq, Join, Star };
+
+struct PathDiscriminant {
+  PathKind kind = PathKind::Zero;
+  std::uint32_t atom = 0;  // meaningful only when kind == Atom
+  std::uint32_t arity = 0;
+
+  friend bool operator==(const PathDiscriminant &lhs,
+                         const PathDiscriminant &rhs) {
+    return lhs.kind == rhs.kind && lhs.atom == rhs.atom &&
+           lhs.arity == rhs.arity;
+  }
+  friend bool operator!=(const PathDiscriminant &lhs,
+                         const PathDiscriminant &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+// A path-expression e-node. Satisfies the lotus::egraph Language concept.
+class PathNode {
+public:
+  using Discriminant = PathDiscriminant;
+
+  PathNode() = default;
+
+  // Named constructors (mirror the previous make* free functions).
+  static PathNode zero() { return PathNode(PathKind::Zero, 0, {}); }
+  static PathNode one() { return PathNode(PathKind::One, 0, {}); }
+  static PathNode atom(std::uint32_t id) { return PathNode(PathKind::Atom, id, {}); }
+  static PathNode seq(std::vector<Id> children) {
+    return PathNode(PathKind::Seq, 0, std::move(children));
+  }
+  static PathNode join(std::vector<Id> children) {
+    return PathNode(PathKind::Join, 0, std::move(children));
+  }
+  static PathNode star(Id body) {
+    return PathNode(PathKind::Star, 0, std::vector<Id>{body});
+  }
+
+  PathKind kind() const { return kind_; }
+  std::uint32_t atomId() const { return atom_; }
+
+  const std::vector<Id> &children() const { return children_; }
+  std::vector<Id> &childrenMut() { return children_; }
+
+  Discriminant discriminant() const {
+    return Discriminant{kind_, atom_,
+                        static_cast<std::uint32_t>(children_.size())};
+  }
+
+  bool matches(const PathNode &other) const {
+    return kind_ == other.kind_ && atom_ == other.atom_ &&
+           children_.size() == other.children_.size();
+  }
+
+  template <typename F> void forEach(F &&fn) const {
+    for (Id id : children_) {
+      fn(id);
+    }
+  }
+  template <typename F> void forEachMut(F &&fn) {
+    for (Id &id : children_) {
+      fn(id);
+    }
+  }
+
+  template <typename F> PathNode mapChildren(F &&fn) const {
+    PathNode copy = *this;
+    for (Id &id : copy.children_) {
+      id = fn(id);
+    }
+    return copy;
+  }
+
+  bool isLeaf() const { return children_.empty(); }
+
+  friend bool operator==(const PathNode &lhs, const PathNode &rhs) {
+    return lhs.kind_ == rhs.kind_ && lhs.atom_ == rhs.atom_ &&
+           lhs.children_ == rhs.children_;
+  }
+  friend bool operator!=(const PathNode &lhs, const PathNode &rhs) {
+    return !(lhs == rhs);
+  }
+  // Numeric atom ordering (atom 2 < atom 10), unlike the old string order.
+  friend bool operator<(const PathNode &lhs, const PathNode &rhs) {
+    return std::tie(lhs.kind_, lhs.atom_, lhs.children_) <
+           std::tie(rhs.kind_, rhs.atom_, rhs.children_);
+  }
+
+private:
+  PathNode(PathKind kind, std::uint32_t atom, std::vector<Id> children)
+      : kind_(kind), atom_(atom), children_(std::move(children)) {}
+
+  PathKind kind_ = PathKind::Zero;
+  std::uint32_t atom_ = 0;
+  std::vector<Id> children_;
+};
+
+// The e-graph language EAN operates on.
+using PathLang = PathNode;
+
+// ---- node kind classification ----------------------------------------------
+
+inline bool isZero(const PathLang &n) { return n.kind() == PathKind::Zero; }
+inline bool isOne(const PathLang &n) { return n.kind() == PathKind::One; }
+inline bool isJoin(const PathLang &n) { return n.kind() == PathKind::Join; }
+inline bool isSeq(const PathLang &n) { return n.kind() == PathKind::Seq; }
+inline bool isStar(const PathLang &n) { return n.kind() == PathKind::Star; }
+inline bool isAtom(const PathLang &n) { return n.kind() == PathKind::Atom; }
+
+// Precondition: isAtom(n) is true.
+inline std::uint32_t parseAtomId(const PathLang &n) { return n.atomId(); }
+
+// ---- node builders ----------------------------------------------------------
+
+inline PathLang makeZero() { return PathLang::zero(); }
+inline PathLang makeOne() { return PathLang::one(); }
+inline PathLang makeAtom(std::uint32_t id) { return PathLang::atom(id); }
+inline PathLang makeJoin(std::vector<Id> children) {
+  return PathLang::join(std::move(children));
+}
+inline PathLang makeSeq(std::vector<Id> children) {
+  return PathLang::seq(std::move(children));
+}
+inline PathLang makeStar(Id body) { return PathLang::star(body); }
+
+} // namespace ean
+} // namespace elimination
+
+// ---- Language concept: node display (the e-graph instantiates displayNode<L>
+// for its dot/debug path). JSON decode (LanguageOps::fromOp) is not used by EAN,
+// so only the display half is provided. --------------------------------------
+
+namespace lotus::egraph {
+
+template <> struct LanguageOps<::elimination::ean::PathNode> {
+  static std::string display(const ::elimination::ean::PathNode &node) {
+    using Kind = ::elimination::ean::PathKind;
+    switch (node.kind()) {
+    case Kind::Zero:
+      return "zero";
+    case Kind::One:
+      return "one";
+    case Kind::Atom:
+      return "atom#" + std::to_string(node.atomId());
+    case Kind::Seq:
+      return "seq";
+    case Kind::Join:
+      return "join";
+    case Kind::Star:
+      return "star";
+    }
+    return "zero";
+  }
+};
+
+} // namespace lotus::egraph
+
+// ---- hashing (required by the e-graph's unordered_map memo/index) -----------
+
+template <> struct std::hash<::elimination::ean::PathDiscriminant> {
+  size_t operator()(
+      const ::elimination::ean::PathDiscriminant &value) const noexcept {
+    size_t seed = static_cast<size_t>(value.kind);
+    ::lotus::egraph::hashCombine(seed, value.atom);
+    ::lotus::egraph::hashCombine(seed, value.arity);
+    return seed;
+  }
+};
+
+template <> struct std::hash<::elimination::ean::PathNode> {
+  size_t operator()(const ::elimination::ean::PathNode &value) const noexcept {
+    size_t seed = static_cast<size_t>(value.kind());
+    ::lotus::egraph::hashCombine(seed, value.atomId());
+    for (::lotus::egraph::Id child : value.children()) {
+      ::lotus::egraph::hashCombine(seed, child);
+    }
+    return seed;
+  }
+};
+
+#endif // DATAFLOW_APA_EAN_PATHLANG_H_

--- a/include/Dataflow/APA/EAN/Saturate.h
+++ b/include/Dataflow/APA/EAN/Saturate.h
@@ -1,0 +1,165 @@
+#ifndef DATAFLOW_APA_EAN_SATURATE_H_
+#define DATAFLOW_APA_EAN_SATURATE_H_
+
+// Saturate: the guarded, budgeted, anytime saturation driver (paper
+// Algorithm 1). It runs the phases [Cleanup, Factor, Star, Explore]; within a
+// phase it repeats {apply-round, rebuild (done by the pass), extract-cost,
+// track-plateau} until a phase saturates or a budget bound is hit.
+//
+// M3 status: only FACTOR is a real rewrite (M2). CLEANUP is already enforced by
+// canon:: at construction, and STAR/EXPLORE arrive in M5, so those phases are
+// no-op slots for now. The value delivered here is the R2 machinery: bounded
+// exploration with a valid result at every stopping point.
+//
+// Because the e-graph only grows (saturation adds equivalent forms, never
+// removes), the best extractable candidate always comes from the final graph —
+// so per-round extraction is used only for the plateau signal, and the actual
+// best is extracted once, at the end (see EAN.h).
+
+#include <algorithm>
+#include <chrono>
+#include <initializer_list>
+#include <vector>
+
+#include "Dataflow/APA/EAN/Budget.h"
+#include "Dataflow/APA/EAN/Canonical.h"
+#include "Dataflow/APA/EAN/Expand.h"
+#include "Dataflow/APA/EAN/ExtractOptions.h"
+#include "Dataflow/APA/EAN/Factorize.h"
+#include "Dataflow/APA/EAN/LawProfile.h"
+#include "Dataflow/APA/EAN/Star.h"
+#include "Solvers/EGraph/Analysis.h"
+#include "Solvers/EGraph/Extract.h"
+
+namespace elimination {
+namespace ean {
+
+enum class Phase { Cleanup, Factor, Star, Explore };
+
+// One round of a phase. Returns the number of new equivalent forms added.
+inline std::size_t applyPhaseRound(Phase p, Graph &g, const LawProfile &L,
+                                   const ExtractOptions &opts) {
+  switch (p) {
+  case Phase::Factor:
+    return factorizeRound(g, L);
+  case Phase::Star:
+    return slideRound(g, L);
+  case Phase::Explore:
+    return expandRound(g, L, opts); // guarded expansion (Explore phase)
+  case Phase::Cleanup: // canonical laws enforced at construction (M1)
+    return 0;
+  }
+  return 0;
+}
+
+// One unscheduled round: apply every rewrite family together (no phase
+// ordering). Used for the "No phase schedule" ablation.
+inline std::size_t applyAllRewrites(Graph &g, const LawProfile &L,
+                                    const ExtractOptions &opts) {
+  std::size_t changed = 0;
+  changed += factorizeRound(g, L);
+  changed += slideRound(g, L);
+  changed += expandRound(g, L, opts);
+  return changed;
+}
+
+// Client-weighted tree cost of the current best extraction, summed over roots.
+// Used as the plateau signal (cross-root sharing is double-counted, which is
+// fine for a monotone stop heuristic; the real objective arrives in M4).
+template <typename CostFn>
+double extractCost(const Graph &g, const std::vector<Id> &roots,
+                   const CostFn &cost_fn) {
+  ::lotus::egraph::Extractor<PathLang, ::lotus::egraph::NoAnalysis<PathLang>,
+                             CostFn>
+      ex(g, cost_fn);
+  double total = 0.0;
+  for (Id r : roots) {
+    total += static_cast<double>(ex.findBestCost(r));
+  }
+  return total;
+}
+
+// Run the phased, budgeted saturation in place on `g`. `costEval(g, roots)`
+// returns the current scalar cost (the plateau signal) — inject the tree cost
+// or the reuse-aware Eq. 5 cost to switch plateau modes. Returns metrics.
+// `opts.scheduled` selects the phase-ordered schedule (default) or the
+// unscheduled "apply everything each round" ablation mode.
+template <typename CostEval>
+SaturationStats saturate(Graph &g, const std::vector<Id> &roots,
+                         const LawProfile &L, const Budget &B,
+                         const ExtractOptions &opts, CostEval &&costEval) {
+  SaturationStats st;
+  st.peakNodes = g.totalSize();
+  st.initCost = costEval(g, roots);
+  double best = st.initCost;
+  std::size_t plateau = 0;
+  const auto start = std::chrono::steady_clock::now();
+
+  // Account for one applied round and test all budget bounds. Returns true when
+  // saturation should stop (and records the stop reason).
+  auto accountAndCheck = [&]() -> bool {
+    ++st.rounds;
+    st.peakNodes = std::max(st.peakNodes, g.totalSize());
+    const double c = costEval(g, roots);
+    if (c < best) {
+      best = c;
+      plateau = 0;
+    } else {
+      ++plateau;
+    }
+    const double elapsed =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - start)
+            .count();
+    if (st.rounds >= B.roundLimit) {
+      st.stop = StopReason::RoundLimit;
+      return true;
+    }
+    if (g.totalSize() >= B.nodeLimit) {
+      st.stop = StopReason::NodeLimit;
+      return true;
+    }
+    if (plateau >= B.plateauLimit) {
+      st.stop = StopReason::Plateau;
+      return true;
+    }
+    if (elapsed >= B.timeLimitSec) {
+      st.stop = StopReason::TimeLimit;
+      return true;
+    }
+    return false;
+  };
+
+  bool stop = false;
+  if (opts.scheduled) {
+    for (Phase p :
+         {Phase::Cleanup, Phase::Factor, Phase::Star, Phase::Explore}) {
+      while (!stop) {
+        const std::size_t changed = applyPhaseRound(p, g, L, opts);
+        if (changed == 0) {
+          break; // this phase has saturated; advance to the next phase
+        }
+        stop = accountAndCheck();
+      }
+      if (stop) {
+        break;
+      }
+    }
+  } else {
+    // Unscheduled: apply every rewrite family together each round.
+    while (!stop) {
+      const std::size_t changed = applyAllRewrites(g, L, opts);
+      if (changed == 0) {
+        break;
+      }
+      stop = accountAndCheck();
+    }
+  }
+
+  st.finalCost = best;
+  return st;
+}
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_SATURATE_H_

--- a/include/Dataflow/APA/EAN/Star.h
+++ b/include/Dataflow/APA/EAN/Star.h
@@ -1,0 +1,136 @@
+#ifndef DATAFLOW_APA_EAN_STAR_H_
+#define DATAFLOW_APA_EAN_STAR_H_
+
+// Star-family rewrites (paper Table I, §III.C). M5 implements SLIDING:
+//
+//     (a·w)*·a  =  a·(w·a)*        (Kleene sliding; Law::Sliding)
+//
+// as a direct variadic-sequence pass, mirroring Factorize. It matches an
+// adjacent pair inside a SEQ where the left element is a star whose body begins
+// with the class that immediately follows it, and adds the "slid" form as an
+// equivalent representation (the original is retained; extraction chooses).
+// Star NORMALIZATION ((a*)*=a*, 0*=1*=1) is already enforced unconditionally by
+// canon::star at construction, so it needs no rule here. Star UNFOLDING (which
+// makes the e-graph cyclic) and the EXPLORE phase are deferred; cycle-safe
+// extraction (M4) is already in place for when unfolding lands.
+//
+// Sliding does not create cycles; the rewritten star (w·a)* is an ordinary
+// finite star. Termination follows from canonical hash-consing (re-running
+// yields the same interned nodes → uniteChecked no-op).
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "Dataflow/APA/EAN/Canonical.h"
+#include "Dataflow/APA/EAN/LawProfile.h"
+#include "Dataflow/APA/EAN/PathLang.h"
+
+namespace elimination {
+namespace ean {
+namespace detail {
+
+// If class `c` contains a star e-node, set `bodyClass` to its body's canonical
+// class id and return true (first star node wins — an M5 simplification).
+inline bool starBodyClass(Graph &g, Id c, Id &bodyClass) {
+  for (const PathLang &n : g[c].nodes) {
+    if (isStar(n)) {
+      bodyClass = g.find(n.children().front());
+      return true;
+    }
+  }
+  return false;
+}
+
+// Body element sequence: the SEQ elements of `bodyClass`, or `[bodyClass]` if
+// the body is not a sequence (single atom/star/join).
+inline void bodyElems(Graph &g, Id bodyClass, std::vector<Id> &out) {
+  out.clear();
+  for (const PathLang &n : g[bodyClass].nodes) {
+    if (isSeq(n)) {
+      out.reserve(n.children().size());
+      for (Id e : n.children()) {
+        out.push_back(g.find(e));
+      }
+      return;
+    }
+  }
+  out.push_back(g.find(bodyClass));
+}
+
+struct SlideAction {
+  Id classId;              // the SEQ e-class gaining an alternative
+  std::vector<Id> prefix;  // elems[0 .. i-1]
+  Id a{};                  // first(body) == elems[i+1]
+  std::vector<Id> rotated; // body[1:] ++ [a]  -> new star body
+  std::vector<Id> suffix;  // elems[i+2 .. ]
+};
+
+} // namespace detail
+
+// One round of sliding over the whole e-graph. Returns the number of e-classes
+// that gained a new representation.
+inline std::size_t slideRound(Graph &g, const LawProfile &L) {
+  if (!L.has(Law::Sliding)) {
+    return 0;
+  }
+
+  // Phase A: scan (read-only — no add / no unite).
+  std::vector<detail::SlideAction> actions;
+  for (Id c0 : g.classIds()) {
+    const Id c = g.find(c0);
+    const auto &cls = g[c];
+    for (const PathLang &node : cls.nodes) {
+      if (!isSeq(node)) {
+        continue;
+      }
+      std::vector<Id> elems;
+      elems.reserve(node.children().size());
+      for (Id e : node.children()) {
+        elems.push_back(g.find(e));
+      }
+      for (std::size_t i = 0; i + 1 < elems.size(); ++i) {
+        Id bodyClass;
+        if (!detail::starBodyClass(g, elems[i], bodyClass)) {
+          continue;
+        }
+        std::vector<Id> body;
+        detail::bodyElems(g, bodyClass, body);
+        if (body.empty() || !(body.front() == elems[i + 1])) {
+          continue; // trailing element must equal the star body's first element
+        }
+        detail::SlideAction act;
+        act.classId = c;
+        act.prefix.assign(elems.begin(), elems.begin() + i);
+        act.a = body.front();
+        act.rotated.assign(body.begin() + 1, body.end());
+        act.rotated.push_back(body.front());
+        act.suffix.assign(elems.begin() + i + 2, elems.end());
+        actions.push_back(std::move(act));
+      }
+    }
+  }
+
+  // Phase B: build the slid forms and unite them in.
+  std::size_t changes = 0;
+  for (auto &act : actions) {
+    const Id newStar = canon::star(g, canon::seq(g, act.rotated));
+    std::vector<Id> elems = act.prefix;
+    elems.push_back(act.a);
+    elems.push_back(newStar);
+    elems.insert(elems.end(), act.suffix.begin(), act.suffix.end());
+    const Id newSeq = canon::seq(g, std::move(elems));
+    if (g.uniteChecked(act.classId, newSeq).second) {
+      ++changes;
+    }
+  }
+
+  // canon::* dirties the e-graph even on memo hits; always restore clean state.
+  g.rebuild();
+  return changes;
+}
+
+} // namespace ean
+} // namespace elimination
+
+#endif // DATAFLOW_APA_EAN_STAR_H_

--- a/include/Dataflow/APA/Solver/ADTDelayedSolver.h
+++ b/include/Dataflow/APA/Solver/ADTDelayedSolver.h
@@ -140,7 +140,9 @@ bool solveADTDelayedWith(IntraEliminationSolverContext<AnalysisTypesT> &Ctx,
     auto *Leaf = It->second;
     auto E = Ctx.evalUF(Leaf);
     Ctx.Results.ExprTo(N) = E;
-    Ctx.Results.IN(N) = Ctx.eval(E, Init);
+    if (!Ctx.Opts.EnableEAN) {
+      Ctx.Results.IN(N) = Ctx.eval(E, Init);
+    }
   }
   return true;
 }

--- a/include/Dataflow/APA/Solver/ADTSimpleSolver.h
+++ b/include/Dataflow/APA/Solver/ADTSimpleSolver.h
@@ -129,7 +129,9 @@ bool solveADTSimpleWith(IntraEliminationSolverContext<AnalysisTypesT> &Ctx,
     }
     auto *Leaf = It->second;
     Ctx.Results.ExprTo(N) = Leaf->SimpleExpr;
-    Ctx.Results.IN(N) = Ctx.eval(Leaf->SimpleExpr, Init);
+    if (!Ctx.Opts.EnableEAN) {
+      Ctx.Results.IN(N) = Ctx.eval(Leaf->SimpleExpr, Init);
+    }
   }
   return true;
 }

--- a/include/Dataflow/APA/Solver/CallGraphSCC.h
+++ b/include/Dataflow/APA/Solver/CallGraphSCC.h
@@ -1,0 +1,198 @@
+#ifndef DATAFLOW_APA_SOLVER_CALLGRAPHSCC_H_
+#define DATAFLOW_APA_SOLVER_CALLGRAPHSCC_H_
+
+#include <algorithm>
+#include <cstddef>
+#include <deque>
+#include <unordered_map>
+#include <vector>
+
+namespace elimination {
+
+// Call graph over procedures (f_t), condensed into strongly-connected
+// components in reverse-topological order (callees before callers), for the
+// modular interprocedural APA solver (E6). Procedures are discovered from a set
+// of entry procedures by walking each procedure's instructions, so the build is
+// fully generic over the interprocedural CFG interface: it only uses
+//   ICF.getAllInstructionsOf(f_t)  -> instructions of a procedure
+//   ICF.isCallSite(n_t)            -> is this a call
+//   ICF.getCalleesOfCallAt(n_t)    -> callees at a call site (set; indirect ok)
+//   ICF.getStartPointsOf(f_t)      -> entry nodes (empty => opaque/external)
+//   ICF.getExitPointsOf(f_t)       -> exit nodes  (empty => opaque/external)
+//
+// External / declaration-only callees (no start or exit points) are treated as
+// opaque: no summary, no call-graph edge (their call sites are handled by the
+// call-to-return bypass downstream, matching ForwardInterSummarySolver).
+template <typename FunctionT> struct CallGraphComponent final {
+  std::vector<FunctionT> procs; // members of this SCC
+  bool recursive = false;       // size > 1, or a self-edge
+};
+
+template <typename FunctionT> struct CallGraphSCCResult final {
+  // Reverse-topological: a component's callees appear before it. A modular
+  // solver can therefore compute summaries in a single left-to-right pass.
+  std::vector<CallGraphComponent<FunctionT>> order;
+};
+
+template <typename NodeT, typename FunctionT, typename ICFTy>
+class CallGraphSCCBuilder final {
+public:
+  using n_t = NodeT;
+  using f_t = FunctionT;
+
+  explicit CallGraphSCCBuilder(const ICFTy &ICF) : ICF(ICF) {}
+
+  // Build the condensed call graph reachable from Entries. A procedure with no
+  // start or exit points is opaque (external) and is never added as a node.
+  CallGraphSCCResult<f_t> build(const std::vector<f_t> &Entries) {
+    Procs.clear();
+    Index.clear();
+    Adj.clear();
+
+    std::deque<f_t> Worklist;
+    for (const auto &E : Entries) {
+      if (isOpaque(E)) {
+        continue;
+      }
+      if (intern(E).second) {
+        Worklist.push_back(E);
+      }
+    }
+
+    while (!Worklist.empty()) {
+      const f_t F = Worklist.front();
+      Worklist.pop_front();
+      const std::size_t Fi = Index.at(F);
+      for (const auto &Inst : ICF.getAllInstructionsOf(F)) {
+        if (!ICF.isCallSite(Inst)) {
+          continue;
+        }
+        for (const auto &Callee : ICF.getCalleesOfCallAt(Inst)) {
+          if (isOpaque(Callee)) {
+            continue; // external/declaration-only: opaque, no edge
+          }
+          auto [Ci, Fresh] = intern(Callee);
+          addEdge(Fi, Ci);
+          if (Fresh) {
+            Worklist.push_back(Callee);
+          }
+        }
+      }
+    }
+
+    return condense();
+  }
+
+private:
+  bool isOpaque(const f_t &F) const {
+    return ICF.getStartPointsOf(F).empty() || ICF.getExitPointsOf(F).empty();
+  }
+
+  // Returns (index, freshly-inserted?).
+  std::pair<std::size_t, bool> intern(const f_t &F) {
+    auto It = Index.find(F);
+    if (It != Index.end()) {
+      return {It->second, false};
+    }
+    const std::size_t Id = Procs.size();
+    Procs.push_back(F);
+    Index.emplace(F, Id);
+    Adj.emplace_back();
+    return {Id, true};
+  }
+
+  void addEdge(std::size_t From, std::size_t To) {
+    auto &Row = Adj[From];
+    if (std::find(Row.begin(), Row.end(), To) == Row.end()) {
+      Row.push_back(To);
+    }
+  }
+
+  // Iterative Tarjan SCC (explicit stack; no recursion so deep call graphs
+  // cannot overflow). Tarjan emits components in reverse-topological order,
+  // which is exactly the order the modular solver wants.
+  CallGraphSCCResult<f_t> condense() const {
+    const std::size_t N = Procs.size();
+    CallGraphSCCResult<f_t> Out;
+
+    std::vector<int> Idx(N, -1);
+    std::vector<int> Low(N, 0);
+    std::vector<bool> OnStack(N, false);
+    std::vector<std::size_t> Stack;
+    std::vector<std::size_t> CompOf(N, static_cast<std::size_t>(-1));
+    int Next = 0;
+
+    // Explicit DFS frame: node + position in its adjacency list.
+    struct Frame final {
+      std::size_t V;
+      std::size_t Edge;
+    };
+    std::vector<Frame> Work;
+
+    for (std::size_t Root = 0; Root < N; ++Root) {
+      if (Idx[Root] != -1) {
+        continue;
+      }
+      Work.push_back({Root, 0});
+      while (!Work.empty()) {
+        auto &Fr = Work.back();
+        const std::size_t V = Fr.V;
+        if (Fr.Edge == 0 && Idx[V] == -1) {
+          Idx[V] = Low[V] = Next++;
+          Stack.push_back(V);
+          OnStack[V] = true;
+        }
+        if (Fr.Edge < Adj[V].size()) {
+          const std::size_t W = Adj[V][Fr.Edge++];
+          if (Idx[W] == -1) {
+            Work.push_back({W, 0});
+          } else if (OnStack[W]) {
+            Low[V] = std::min(Low[V], Idx[W]);
+          }
+          continue;
+        }
+        // All successors processed: settle V.
+        if (Low[V] == Idx[V]) {
+          CallGraphComponent<f_t> C;
+          bool SelfEdge = false;
+          while (true) {
+            const std::size_t W = Stack.back();
+            Stack.pop_back();
+            OnStack[W] = false;
+            CompOf[W] = Out.order.size();
+            C.procs.push_back(Procs[W]);
+            if (W == V) {
+              break;
+            }
+          }
+          // Self-edge detection for a singleton (direct recursion).
+          if (C.procs.size() == 1) {
+            for (std::size_t W : Adj[V]) {
+              if (W == V) {
+                SelfEdge = true;
+                break;
+              }
+            }
+          }
+          C.recursive = C.procs.size() > 1 || SelfEdge;
+          Out.order.push_back(std::move(C));
+        }
+        const std::size_t Settled = V;
+        Work.pop_back();
+        if (!Work.empty()) {
+          Low[Work.back().V] = std::min(Low[Work.back().V], Low[Settled]);
+        }
+      }
+    }
+    return Out;
+  }
+
+  const ICFTy &ICF;
+  std::vector<f_t> Procs;
+  std::unordered_map<f_t, std::size_t> Index;
+  std::vector<std::vector<std::size_t>> Adj;
+};
+
+} // namespace elimination
+
+#endif // DATAFLOW_APA_SOLVER_CALLGRAPHSCC_H_

--- a/include/Dataflow/APA/Solver/EliminationOrder.h
+++ b/include/Dataflow/APA/Solver/EliminationOrder.h
@@ -1,0 +1,181 @@
+#ifndef DATAFLOW_APA_ENGINES_ELIMINATIONORDER_H_
+#define DATAFLOW_APA_ENGINES_ELIMINATIONORDER_H_
+
+// Cost-aware elimination ordering for the state-elimination engine (paper's
+// "Order" configuration; §II Eq. 1 and §III.f "Composition with elimination
+// ordering").
+//
+// Eliminating a vertex k performs, for all i, j:
+//     M[i][j] |= M[i][k] · M[k][k]* · M[k][j].
+// The number and size of the intermediate updates is driven by the
+// predecessor–successor product deg_in(k) · deg_out(k): k contributes one
+// update per (predecessor, successor) pair and adds a fill edge i→j for each
+// such pair. Choosing the pivot order therefore controls peak construction
+// cost, but never the final all-pairs result (the k-loop is a Floyd–Warshall
+// closure: the set of paths — hence the semantics under any distributive
+// client algebra — is invariant to the order).
+//
+// This header is a pure combinatorial model over a boolean elimination graph:
+// it never touches the expression matrix, so it is LLVM-free and unit-testable
+// in isolation. computeCostAwareOrder yields the greedy minimum-product
+// permutation; simulateCost scores ANY permutation (including the baseline's)
+// so the evaluation can compare orders (RQ3).
+
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+
+namespace elimination {
+namespace order {
+
+// Directed graph over node indices [0, n). No self-loops are stored (they do
+// not affect the predecessor–successor product) — build() and fill both skip
+// i == j.
+struct EliminationGraph {
+  std::size_t n = 0;
+  std::vector<std::unordered_set<std::size_t>> preds;
+  std::vector<std::unordered_set<std::size_t>> succs;
+
+  explicit EliminationGraph(std::size_t N = 0) : n(N), preds(N), succs(N) {}
+
+  void addEdge(std::size_t i, std::size_t j) {
+    if (i == j) {
+      return;
+    }
+    if (succs[i].insert(j).second) {
+      preds[j].insert(i);
+    }
+  }
+
+  std::size_t totalEdges() const {
+    std::size_t e = 0;
+    for (const auto &s : succs) {
+      e += s.size();
+    }
+    return e;
+  }
+};
+
+// Aggregate cost of running elimination in a given order over a boolean graph.
+struct OrderCost {
+  // Σ_k deg_in(k)·deg_out(k) at the moment k is eliminated — the paper's
+  // predecessor–successor product summed over the elimination (a count-based
+  // proxy for total intermediate updates / raw-DAG construction work).
+  double totalProduct = 0.0;
+  // Peak number of edges in the (fill-augmented) elimination graph at any point
+  // — a proxy for peak construction density / retained intermediate size.
+  std::size_t peakFill = 0;
+};
+
+namespace detail {
+
+// Eliminate vertex k in place: add a fill edge from every live predecessor to
+// every live successor, then detach k. Returns the number of NEW fill edges
+// added (edges that were not already present). `removed` is set to the number
+// of edges incident to k that are deleted.
+inline std::size_t eliminate(EliminationGraph &g, std::size_t k,
+                             std::size_t &removed) {
+  std::size_t added = 0;
+  for (std::size_t i : g.preds[k]) {
+    for (std::size_t j : g.succs[k]) {
+      if (i == j) {
+        continue;
+      }
+      if (g.succs[i].insert(j).second) {
+        g.preds[j].insert(i);
+        ++added;
+      }
+    }
+  }
+  removed = g.preds[k].size() + g.succs[k].size();
+  for (std::size_t i : g.preds[k]) {
+    g.succs[i].erase(k);
+  }
+  for (std::size_t j : g.succs[k]) {
+    g.preds[j].erase(k);
+  }
+  g.preds[k].clear();
+  g.succs[k].clear();
+  return added;
+}
+
+} // namespace detail
+
+// Greedy minimum-product elimination order. At each step, among the not-yet-
+// eliminated vertices, pick the one minimizing deg_in·deg_out on the current
+// (fill-augmented) graph; ties broken by deg_in+deg_out, then by index — so the
+// result is fully deterministic and independent of hash-set iteration order.
+// Returns a permutation of [0, n).
+inline std::vector<std::size_t> computeCostAwareOrder(const EliminationGraph &g0) {
+  const std::size_t n = g0.n;
+  std::vector<std::size_t> order;
+  order.reserve(n);
+  if (n == 0) {
+    return order;
+  }
+
+  EliminationGraph g = g0; // working copy (mutated by elimination)
+  std::vector<bool> dead(n, false);
+
+  for (std::size_t step = 0; step < n; ++step) {
+    std::size_t best = n;
+    std::size_t bestProd = 0, bestDeg = 0;
+    for (std::size_t k = 0; k < n; ++k) {
+      if (dead[k]) {
+        continue;
+      }
+      const std::size_t in = g.preds[k].size();
+      const std::size_t out = g.succs[k].size();
+      const std::size_t prod = in * out;
+      const std::size_t deg = in + out;
+      if (best == n || prod < bestProd ||
+          (prod == bestProd && deg < bestDeg)) {
+        best = k;
+        bestProd = prod;
+        bestDeg = deg;
+      }
+    }
+    std::size_t removed = 0;
+    detail::eliminate(g, best, removed);
+    dead[best] = true;
+    order.push_back(best);
+  }
+  return order;
+}
+
+// Score an arbitrary elimination order on `g0` (a fresh copy is used, so `g0`
+// is not modified). Any node in `order` that is not a valid live index is
+// skipped defensively. Nodes missing from `order` are not scored.
+inline OrderCost simulateCost(const EliminationGraph &g0,
+                              const std::vector<std::size_t> &order) {
+  OrderCost cost;
+  EliminationGraph g = g0;
+  std::vector<bool> dead(g.n, false);
+  std::size_t edges = g.totalEdges();
+  cost.peakFill = edges;
+
+  for (std::size_t k : order) {
+    if (k >= g.n || dead[k]) {
+      continue;
+    }
+    const std::size_t in = g.preds[k].size();
+    const std::size_t out = g.succs[k].size();
+    cost.totalProduct += static_cast<double>(in) * static_cast<double>(out);
+
+    std::size_t removed = 0;
+    const std::size_t added = detail::eliminate(g, k, removed);
+    // Transient density: fill added while k's own edges are still present.
+    const std::size_t transient = edges + added;
+    if (transient > cost.peakFill) {
+      cost.peakFill = transient;
+    }
+    edges = transient - removed;
+    dead[k] = true;
+  }
+  return cost;
+}
+
+} // namespace order
+} // namespace elimination
+
+#endif // DATAFLOW_APA_ENGINES_ELIMINATIONORDER_H_

--- a/include/Dataflow/APA/Solver/ForwardInterSummarySolver.h
+++ b/include/Dataflow/APA/Solver/ForwardInterSummarySolver.h
@@ -3,15 +3,20 @@
 
 #include "Dataflow/APA/Core/InterProblem.h"
 #include "Dataflow/APA/Core/InterResult.h"
+#include "Dataflow/APA/EAN/DagStats.h"
+#include "Dataflow/APA/EAN/EAN.h"
+#include "Dataflow/APA/EAN/Greedy.h"
 #include "Dataflow/APA/Solver/InterSummaryTransfer.h"
 #include "Dataflow/APA/Solver/PathSummaryEquationSolver.h"
 #include "Dataflow/ControlFlow/FlowDirection.h"
 #include "Dataflow/Mono/Core/CallStringContext.h"
 
+#include <chrono>
 #include <deque>
 #include <map>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -50,6 +55,19 @@ public:
       }
       return Ctx < Other.Ctx;
     }
+
+    bool operator==(const ContextKey &Other) const {
+      return Inst == Other.Inst && Ctx == Other.Ctx;
+    }
+  };
+
+  struct ContextKeyHash final {
+    std::size_t operator()(const ContextKey &Key) const {
+      std::size_t H = std::hash<n_t>{}(Key.Inst);
+      H ^= std::hash<Context>{}(Key.Ctx) + 0x9e3779b97f4a7c15ULL + (H << 6) +
+           (H >> 2);
+      return H;
+    }
   };
 
   using atom_t = InterSummaryTransferAtom<AnalysisTypesT>;
@@ -60,6 +78,13 @@ public:
     PathSummaryEquationDiagnostics equation_graph;
     std::size_t discovered_context_node_count = 0;
     std::size_t seed_count = 0;
+    // EAN/Greedy post-pass instrumentation (see applySummaryPostPass). Zero
+    // unless the pass ran.
+    std::size_t gen_time_us = 0;
+    std::size_t norm_time_us = 0;
+    std::size_t interp_time_us = 0;
+    ean::DagStats summary_before;
+    ean::DagStats summary_after;
   };
 
   explicit ForwardInterSummarySolver(ProblemTy &Problem,
@@ -81,12 +106,22 @@ public:
     InitialFact = Problem.bottom();
     HaveInitialFact = false;
 
+    const auto GenStart = std::chrono::steady_clock::now();
     discoverEquationGraph();
     auto SolverOptions = Options;
     SolverOptions.Direction = PathSummaryEquationDirection::ForwardPath;
     PathSummaryEquationSolver<ContextKey, atom_t> Solver(Graph, SolverOptions);
     auto Summary = Solver.solve();
     DiagnosticsValue.equation_graph = Summary.diagnostics();
+    DiagnosticsValue.gen_time_us += static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - GenStart)
+            .count());
+
+    // EAN/Greedy post-optimization of the solved summary batch (no-op unless
+    // enabled in Options.EAN). Runs before interpretation so the cheaper,
+    // semantics-preserving IR is what gets evaluated into client facts.
+    applySummaryPostPass(Summary);
 
     Result = result_t{};
     Result.setMissingFactFallback(Problem.bottom());
@@ -109,6 +144,11 @@ public:
     Out.equation_edge_count = DiagnosticsValue.equation_graph.edge_count;
     Out.scc_count = DiagnosticsValue.equation_graph.scc_count;
     Out.cyclic_scc_count = DiagnosticsValue.equation_graph.cyclic_scc_count;
+    Out.gen_time_us = DiagnosticsValue.gen_time_us;
+    Out.norm_time_us = DiagnosticsValue.norm_time_us;
+    Out.interp_time_us = DiagnosticsValue.interp_time_us;
+    Out.summary_before = DiagnosticsValue.summary_before;
+    Out.summary_after = DiagnosticsValue.summary_after;
     return Out;
   }
 
@@ -259,6 +299,63 @@ private:
     }
   }
 
+  // EAN/Greedy post-optimization: replace each context summary's path
+  // expression with a reuse-aware, cost-minimized equivalent (as one batch),
+  // then interpretation reads the optimized forms. No-op unless Options.EAN
+  // enables a pass. Semantics are preserved because EAN/Greedy preserve
+  // meaning under the client's declared law profile (the default profile is
+  // universally safe); on any internal resource failure ean() falls back to the
+  // original batch (root preservation, I3). The atoms are opaque to EAN and are
+  // re-exported into the same factory (Graph.exprs()) that owns them, so the
+  // evaluator consumes the optimized expressions unchanged.
+  void applySummaryPostPass(
+      PathSummaryEquationResult<ContextKey, atom_t> &Summary) {
+    auto &Sums = Summary.summaries(); // non-const: rewrite values in place
+    if (Sums.empty()) {
+      return;
+    }
+    std::vector<ContextKey> Keys;
+    std::vector<expr_ref_t> Roots;
+    Keys.reserve(Sums.size());
+    Roots.reserve(Sums.size());
+    for (auto &KV : Sums) {
+      Keys.push_back(KV.first);
+      Roots.push_back(KV.second);
+    }
+
+    DiagnosticsValue.summary_before = ean::computeDagStats<atom_t>(Roots);
+    DiagnosticsValue.summary_after = DiagnosticsValue.summary_before;
+
+    const auto &EAN = Options.EAN;
+    if (!EAN.EnableEAN && !EAN.EnableGreedy) {
+      return; // baseline: no post-pass
+    }
+
+    const auto NormStart = std::chrono::steady_clock::now();
+    std::vector<expr_ref_t> Optimized;
+    if (EAN.EnableEAN) {
+      ean::ExtractOptions EO = EAN.EANExtract;
+      EO.gateMinNodes = EAN.EANMinNodes;
+      EO.monotoneGuard = EAN.EANMonotone;
+      Optimized = ean::ean<atom_t>(Roots, EAN.EANLaws, EAN.EANCost,
+                                   EAN.EANBudget, Graph.exprs(), nullptr, EO);
+    } else {
+      Optimized = greedySimplify<atom_t>(Roots, Graph.exprs());
+    }
+    DiagnosticsValue.norm_time_us += static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - NormStart)
+            .count());
+
+    if (Optimized.size() != Roots.size()) {
+      return; // shape mismatch: keep the original summaries (I3)
+    }
+    for (std::size_t I = 0; I < Keys.size(); ++I) {
+      Sums[Keys[I]] = Optimized[I];
+    }
+    DiagnosticsValue.summary_after = ean::computeDagStats<atom_t>(Optimized);
+  }
+
   void evaluateSummaries(
       const PathSummaryEquationResult<ContextKey, atom_t> &Summary) {
     if (!HaveInitialFact) {
@@ -281,7 +378,7 @@ private:
   PathSummaryEquationOptions Options;
   const i_t *ICF = nullptr;
   summary_graph_t Graph;
-  std::set<ContextKey> Discovered;
+  std::unordered_set<ContextKey, ContextKeyHash> Discovered;
   std::unordered_map<n_t, fact_t> SeedFacts;
   fact_t InitialFact{};
   bool HaveInitialFact = false;

--- a/include/Dataflow/APA/Solver/InterSummaryTransfer.h
+++ b/include/Dataflow/APA/Solver/InterSummaryTransfer.h
@@ -30,6 +30,13 @@ template <typename AnalysisTypesT> struct InterSummaryTransferAtom final {
     CallEntry,
     ReturnExit,
     CallToRet,
+    // Symbolic reference to a callee's entry->exit path-expression summary at a
+    // call site (E6 modular interprocedural solver). NOT inlined: evaluation
+    // means In -> callFlow(CallSite,Callee) -> evaluate S_Callee ->
+    // returnFlow(...,RetSite) -> Out, performed by ModularInterSummarySolver's
+    // evaluator, which carries the {callee -> summary} table. The whole-program
+    // ForwardInterSummarySolver never produces this kind.
+    SummaryCall,
   };
 
   static InterSummaryTransferAtom rawNormal(transfer_t Transfer) {
@@ -75,6 +82,19 @@ template <typename AnalysisTypesT> struct InterSummaryTransferAtom final {
     return Atom;
   }
 
+  // E6: symbolic reference to Callee's entry->exit summary at CallSite, returning
+  // to RetSite. Reuses the CallSite/Callee/RetSite fields; evaluated by the
+  // modular solver (milestone 3/4), not by InterSummaryTransferEvaluator.
+  static InterSummaryTransferAtom summaryCall(n_t CallSite, f_t Callee,
+                                              n_t RetSite) {
+    InterSummaryTransferAtom Atom;
+    Atom.K = Kind::SummaryCall;
+    Atom.CallSite = CallSite;
+    Atom.Callee = Callee;
+    Atom.RetSite = RetSite;
+    return Atom;
+  }
+
   Kind K = Kind::Normal;
   transfer_t NormalTransfer{};
   n_t CallSite{};
@@ -82,6 +102,21 @@ template <typename AnalysisTypesT> struct InterSummaryTransferAtom final {
   n_t ExitStmt{};
   n_t RetSite{};
   std::vector<f_t> Callees;
+
+  // Value equality over all discriminant fields. Enables hash-consed dedup of
+  // summary atoms in PathExprFactory (without it the factory mints a fresh node
+  // per atom(), collapsing all structural sharing of the interprocedural DAG).
+  friend bool operator==(const InterSummaryTransferAtom &A,
+                         const InterSummaryTransferAtom &B) {
+    return A.K == B.K && A.NormalTransfer == B.NormalTransfer &&
+           A.CallSite == B.CallSite && A.Callee == B.Callee &&
+           A.ExitStmt == B.ExitStmt && A.RetSite == B.RetSite &&
+           A.Callees == B.Callees;
+  }
+  friend bool operator!=(const InterSummaryTransferAtom &A,
+                         const InterSummaryTransferAtom &B) {
+    return !(A == B);
+  }
 };
 
 template <typename AnalysisTypesT, unsigned K>
@@ -116,6 +151,13 @@ public:
                              Atom.RetSite, In);
     case atom_t::Kind::CallToRet:
       return applyCallToRet(Atom.CallSite, Atom.RetSite, Atom.Callees, In);
+    case atom_t::Kind::SummaryCall:
+      // Unreachable here: SummaryCall atoms are produced only by the modular
+      // interprocedural solver (E6), whose evaluator carries the summary table
+      // needed to evaluate them. This whole-program evaluator never sees one.
+      // Return the same neutral value as the fallback below (bottom()); allTop()
+      // is not part of every inter client's problem interface.
+      return Problem.bottom();
     }
     return Problem.bottom();
   }
@@ -248,5 +290,31 @@ private:
 };
 
 } // namespace elimination
+
+// Hash over all discriminant fields, mirroring operator==. Placed after the
+// type is complete so PathExprFactory<InterSummaryTransferAtom>::atom() selects
+// its hash-consing path (is_std_hashable becomes true).
+namespace std {
+template <typename AnalysisDomainTy>
+struct hash<elimination::InterSummaryTransferAtom<AnalysisDomainTy>> {
+  std::size_t operator()(
+      const elimination::InterSummaryTransferAtom<AnalysisDomainTy> &A) const {
+    using Atom = elimination::InterSummaryTransferAtom<AnalysisDomainTy>;
+    std::size_t H = std::hash<int>{}(static_cast<int>(A.K));
+    const auto mix = [&H](std::size_t V) {
+      H ^= V + 0x9e3779b97f4a7c15ULL + (H << 6) + (H >> 2);
+    };
+    mix(std::hash<typename Atom::transfer_t>{}(A.NormalTransfer));
+    mix(std::hash<typename Atom::n_t>{}(A.CallSite));
+    mix(std::hash<typename Atom::f_t>{}(A.Callee));
+    mix(std::hash<typename Atom::n_t>{}(A.ExitStmt));
+    mix(std::hash<typename Atom::n_t>{}(A.RetSite));
+    for (const auto &C : A.Callees) {
+      mix(std::hash<typename Atom::f_t>{}(C));
+    }
+    return H;
+  }
+};
+} // namespace std
 
 #endif // DATAFLOW_APA_SOLVER_INTERSUMMARYTRANSFER_H_

--- a/include/Dataflow/APA/Solver/ModularInterSummaryDriver.h
+++ b/include/Dataflow/APA/Solver/ModularInterSummaryDriver.h
@@ -1,0 +1,185 @@
+#ifndef DATAFLOW_APA_SOLVER_MODULARINTERSUMMARYDRIVER_H_
+#define DATAFLOW_APA_SOLVER_MODULARINTERSUMMARYDRIVER_H_
+
+#include "Dataflow/APA/Core/InterResult.h"
+#include "Dataflow/APA/Solver/ModularInterSummaryInterpreter.h"
+#include "Dataflow/APA/Solver/ModularInterSummarySolver.h"
+
+#include <chrono>
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+
+namespace elimination {
+
+// Top-level modular interprocedural driver (E6, milestone 4): builds
+// per-procedure summaries, then interprets them into IN/OUT facts with a
+// context-insensitive (functional, D1=A) fixpoint over procedure entry facts.
+// Results use the empty context key (one IN per instruction).
+template <typename AnalysisDomainTy, unsigned K>
+class ModularInterSummaryDriver final {
+public:
+  using ProblemTy = InterEliminationProblem<AnalysisDomainTy>;
+  using fact_t = typename AnalysisDomainTy::fact_t;
+  using n_t = typename AnalysisDomainTy::n_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using transfer_t = typename AnalysisDomainTy::transfer_t;
+  using i_t = typename AnalysisDomainTy::i_t;
+  using result_t = InterDataFlowResultT<K, fact_t, transfer_t, n_t>;
+  using Context = typename result_t::Context;
+  using builder_t = ModularInterSummaryBuilder<AnalysisDomainTy>;
+  using interp_t = ModularInterSummaryInterpreter<AnalysisDomainTy, K>;
+
+  ModularInterSummaryDriver(ProblemTy &Problem, const i_t &ICF,
+                            PathSummaryEquationOptions Options = {})
+      : Problem(Problem), ICF(ICF), Options(Options) {}
+
+  result_t solve(const std::vector<f_t> &Entries, const fact_t &InitialFact) {
+    builder_t Builder(Problem, ICF, Options);
+    auto Built = Builder.build(Entries);
+    interp_t Interp(Problem, ICF, Built.summaries);
+
+    const auto InterpStart = std::chrono::steady_clock::now();
+
+    // Merged entry fact per procedure (functional). Entry procedures start at
+    // InitialFact; callee entry facts accumulate via callFlow at their call
+    // sites, refined to a fixpoint over the reverse-topological order.
+    std::unordered_map<f_t, fact_t> EntryFact;
+    for (const auto &E : Entries) {
+      EntryFact[E] = InitialFact;
+    }
+    seedEntries(Built, EntryFact, InitialFact);
+
+    const std::size_t Cap = Built.summaries.size() + 2;
+    for (std::size_t Pass = 0; Pass < Cap; ++Pass) {
+      Interp.beginPass();
+      // propagate returns whether any procedure entry fact changed this pass.
+      // The interpreter's changedThisPass() only observes the recursion memo
+      // table (procApply), NOT the cross-procedure EntryFact flow driven here,
+      // so the outer fixpoint must watch BOTH signals. Watching only the
+      // interpreter's flag lets the loop break while entry facts are still
+      // propagating down a deep call chain (main -> ... -> leaf), which
+      // under-approximates reachability for the deepest callees.
+      const bool EntryChanged = propagate(Built, Interp, EntryFact);
+      if (!EntryChanged && !Interp.changedThisPass() && Pass > 0) {
+        break;
+      }
+    }
+
+    result_t Result;
+    Result.setMissingFactFallback(Problem.bottom());
+    std::size_t EmittedNodes = 0;
+    emit(Built, Interp, EntryFact, Result, EmittedNodes);
+    const auto InterpUs = static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - InterpStart)
+            .count());
+
+    // Surface the same Table VI/VII diagnostics the whole-program summary solver
+    // reports, so `--modular-inter` prints [inter-summary]/[dagstats-*] and the
+    // Default<->EAN node reduction is directly observable.
+    InterSummarySolveDiagnostics Diag;
+    Diag.discovered_context_node_count = EmittedNodes;
+    Diag.seed_count = Entries.size();
+    Diag.equation_node_count = Built.equationNodeCount;
+    Diag.equation_edge_count = Built.equationEdgeCount;
+    Diag.scc_count = Built.sccCount;
+    Diag.cyclic_scc_count = Built.cyclicSccCount;
+    Diag.gen_time_us = Built.genTimeUs;
+    Diag.norm_time_us = Built.normTimeUs;
+    Diag.interp_time_us = InterpUs;
+    Diag.summary_before = Built.summaryBefore;
+    Diag.summary_after = Built.summaryAfter;
+    Result.setSummarySolveDiagnostics(Diag);
+
+    Result.setSolveStatus(SolveStatus::Ok);
+    return Result;
+  }
+
+private:
+  // Ensure every discovered procedure has an entry-fact slot (default bottom).
+  void seedEntries(const typename builder_t::Result &Built,
+                   std::unordered_map<f_t, fact_t> &EntryFact,
+                   const fact_t &InitialFact) {
+    for (const auto &Comp : Built.callGraph.order) {
+      for (const auto &P : Comp.procs) {
+        EntryFact.emplace(P, Problem.bottom());
+      }
+    }
+    (void)InitialFact;
+  }
+
+  // For each procedure (callees first), evaluate call-site reaching facts and
+  // push callFlow into callees' entry facts. Returns whether any callee entry
+  // fact changed, so the driver's outer fixpoint can detect that entry facts
+  // are still propagating even when the interpreter's recursion memo is stable.
+  bool propagate(const typename builder_t::Result &Built, interp_t &Interp,
+                 std::unordered_map<f_t, fact_t> &EntryFact) {
+    bool EntryChanged = false;
+    for (const auto &Comp : Built.callGraph.order) {
+      for (const auto &P : Comp.procs) {
+        auto SumIt = Built.summaries.find(P);
+        if (SumIt == Built.summaries.end()) {
+          continue;
+        }
+        const fact_t In = EntryFact[P];
+        for (const auto &Inst : ICF.getAllInstructionsOf(P)) {
+          if (!ICF.isCallSite(Inst)) {
+            continue;
+          }
+          auto NodeIt = SumIt->second.perNode.find(Inst);
+          if (NodeIt == SumIt->second.perNode.end()) {
+            continue;
+          }
+          const fact_t AtCall = Interp.evalExpr(NodeIt->second, In);
+          for (const auto &Callee : ICF.getCalleesOfCallAt(Inst)) {
+            auto CalleeIt = EntryFact.find(Callee);
+            if (CalleeIt == EntryFact.end()) {
+              continue; // opaque callee
+            }
+            const fact_t Contribution =
+                Problem.callFlow(Inst, Callee, AtCall);
+            const fact_t Merged =
+                Problem.join(CalleeIt->second, Contribution);
+            if (!Problem.equal(Merged, CalleeIt->second)) {
+              CalleeIt->second = Merged;
+              EntryChanged = true;
+            }
+          }
+        }
+      }
+    }
+    return EntryChanged;
+  }
+
+  void emit(const typename builder_t::Result &Built, interp_t &Interp,
+            const std::unordered_map<f_t, fact_t> &EntryFact,
+            result_t &Result, std::size_t &EmittedNodes) {
+    const Context Empty{};
+    for (const auto &Comp : Built.callGraph.order) {
+      for (const auto &P : Comp.procs) {
+        auto SumIt = Built.summaries.find(P);
+        if (SumIt == Built.summaries.end()) {
+          continue;
+        }
+        auto EF = EntryFact.find(P);
+        const fact_t In = EF == EntryFact.end() ? Problem.bottom() : EF->second;
+        for (const auto &KV : SumIt->second.perNode) {
+          const fact_t IN = Interp.evalExpr(KV.second, In);
+          Result.IN(KV.first, Empty) = IN;
+          Result.OUT(KV.first, Empty) =
+              Problem.applyTransfer(Problem.edgeTransfer(KV.first, n_t{}), IN);
+          ++EmittedNodes;
+        }
+      }
+    }
+  }
+
+  ProblemTy &Problem;
+  const i_t &ICF;
+  PathSummaryEquationOptions Options;
+};
+
+} // namespace elimination
+
+#endif // DATAFLOW_APA_SOLVER_MODULARINTERSUMMARYDRIVER_H_

--- a/include/Dataflow/APA/Solver/ModularInterSummaryInterpreter.h
+++ b/include/Dataflow/APA/Solver/ModularInterSummaryInterpreter.h
@@ -1,0 +1,184 @@
+#ifndef DATAFLOW_APA_SOLVER_MODULARINTERSUMMARYINTERPRETER_H_
+#define DATAFLOW_APA_SOLVER_MODULARINTERSUMMARYINTERPRETER_H_
+
+#include "Dataflow/APA/Core/InterResult.h"
+#include "Dataflow/APA/Solver/ModularInterSummarySolver.h"
+
+#include <cstddef>
+#include <deque>
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace elimination {
+
+// Interpretation for the modular interprocedural summaries (E6, milestone 4).
+//
+// Evaluates the per-procedure entry->node path expressions into client facts.
+// The only non-local case is the SummaryCall atom: In -> callFlow -> evaluate
+// the callee's entry->exit summary -> returnFlow. Recursion (a SummaryCall to a
+// procedure whose evaluation is already on the stack) is closed by a memoized
+// fixpoint (E1): each (callee, exit, input-fact) is evaluated at most once per
+// outer pass; a re-entrant demand returns the current approximation; outer
+// passes repeat until no tabulated value changes (bounded by a cap). This is
+// context-insensitive / functional (D1=A): one merged entry fact per procedure,
+// hence one IN per instruction (empty context key, F1).
+template <typename AnalysisDomainTy, unsigned K>
+class ModularInterSummaryInterpreter final {
+public:
+  using ProblemTy = InterEliminationProblem<AnalysisDomainTy>;
+  using fact_t = typename AnalysisDomainTy::fact_t;
+  using n_t = typename AnalysisDomainTy::n_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using transfer_t = typename AnalysisDomainTy::transfer_t;
+  using i_t = typename AnalysisDomainTy::i_t;
+  using atom_t = InterSummaryTransferAtom<AnalysisDomainTy>;
+  using expr_factory_t = PathExprFactory<atom_t>;
+  using expr_ref_t = typename expr_factory_t::Ref;
+  using builder_t = ModularInterSummaryBuilder<AnalysisDomainTy>;
+  using SummaryTable = typename builder_t::SummaryTable;
+  using result_t = InterDataFlowResultT<K, fact_t, transfer_t, n_t>;
+  using Context = typename result_t::Context;
+
+  ModularInterSummaryInterpreter(ProblemTy &Problem, const i_t &ICF,
+                                 const SummaryTable &Summaries)
+      : Problem(Problem), ICF(ICF), Summaries(Summaries) {}
+
+  // Evaluate one procedure's summary at input fact In, evaluating SummaryCall
+  // atoms through the tabulated callee summaries.
+  fact_t evalExpr(const expr_ref_t &Expr, const fact_t &In) {
+    if (!Expr) {
+      return Problem.bottom();
+    }
+    switch (Expr->K) {
+    case expr_factory_t::Kind::Zero:
+      return Problem.bottom();
+    case expr_factory_t::Kind::One:
+      return In;
+    case expr_factory_t::Kind::Atom:
+      return applyAtom(*Expr->Transfer, In);
+    case expr_factory_t::Kind::Union: {
+      auto L = evalExpr(Expr->L, In);
+      auto R = evalExpr(Expr->R, In);
+      return Problem.join(L, R);
+    }
+    case expr_factory_t::Kind::Concat: {
+      auto Mid = evalExpr(Expr->L, In);
+      return evalExpr(Expr->R, Mid);
+    }
+    case expr_factory_t::Kind::Star: {
+      auto Cur = In;
+      for (std::size_t I = 0; I < kMaxStarIterations; ++I) {
+        auto Next = Problem.join(In, evalExpr(Expr->L, Cur));
+        if (Problem.equal(Next, Cur)) {
+          return Cur;
+        }
+        Cur = std::move(Next);
+      }
+      return Cur;
+    }
+    }
+    return Problem.bottom();
+  }
+
+  bool changedThisPass() const { return Changed; }
+  void beginPass() {
+    Changed = false;
+    ++CurPass;
+  }
+
+private:
+  static constexpr std::size_t kMaxStarIterations = 100000;
+
+  fact_t applyAtom(const atom_t &A, const fact_t &In) {
+    switch (A.K) {
+    case atom_t::Kind::RawNormal:
+      return Problem.applyTransfer(A.NormalTransfer, In);
+    case atom_t::Kind::CallToRet:
+      return Problem.callToRetFlow(A.CallSite, A.RetSite, A.Callees, In);
+    case atom_t::Kind::SummaryCall:
+      return applySummaryCall(A.CallSite, A.Callee, A.RetSite, In);
+    case atom_t::Kind::Normal:
+    case atom_t::Kind::CallEntry:
+    case atom_t::Kind::ReturnExit:
+      // These are not produced by the modular per-procedure graph.
+      return Problem.bottom();
+    }
+    return Problem.bottom();
+  }
+
+  // In -> callFlow -> callee entry->exit_i -> returnFlow, unioned over exits.
+  fact_t applySummaryCall(n_t CallSite, f_t Callee, n_t RetSite,
+                          const fact_t &In) {
+    auto SumIt = Summaries.find(Callee);
+    if (SumIt == Summaries.end()) {
+      return Problem.bottom(); // opaque/unknown callee: no summary
+    }
+    const fact_t CallIn = Problem.callFlow(CallSite, Callee, In);
+    fact_t Out = Problem.bottom();
+    for (const auto &Exit : ICF.getExitPointsOf(Callee)) {
+      if (Exit == n_t{}) {
+        continue;
+      }
+      auto NodeIt = SumIt->second.perNode.find(Exit);
+      if (NodeIt == SumIt->second.perNode.end()) {
+        continue;
+      }
+      const fact_t Ei = procApply(Callee, Exit, NodeIt->second, CallIn);
+      Out = Problem.join(
+          Out, Problem.returnFlowWithCallerFact(CallSite, Callee, Exit, RetSite,
+                                                Ei, In));
+    }
+    return Out;
+  }
+
+  struct Entry final {
+    fact_t In;
+    fact_t Out;
+    bool computing = false;
+    std::size_t visitedPass = 0;
+  };
+
+  // Memoized fixpoint (E1). Recompute at most once per outer pass; a re-entrant
+  // demand (computing) returns the current approximation to break recursion.
+  fact_t procApply(f_t Callee, n_t Exit, const expr_ref_t &ExitExpr,
+                   const fact_t &In) {
+    auto &Bucket = Tab[std::make_pair(Callee, Exit)];
+    for (auto &E : Bucket) {
+      if (Problem.equal(E.In, In)) {
+        if (E.computing || E.visitedPass == CurPass) {
+          return E.Out; // recursion cut, or already refreshed this pass
+        }
+        E.computing = true;
+        fact_t Val = evalExpr(ExitExpr, In);
+        E.computing = false;
+        E.visitedPass = CurPass;
+        if (!Problem.equal(E.Out, Val)) {
+          E.Out = std::move(Val);
+          Changed = true;
+        }
+        return E.Out;
+      }
+    }
+    Bucket.push_back(Entry{In, Problem.bottom(), true, CurPass});
+    Entry &Cur = Bucket.back(); // std::deque: stable across later push_back
+    fact_t Val = evalExpr(ExitExpr, In);
+    Cur.computing = false;
+    if (!Problem.equal(Cur.Out, Val)) {
+      Cur.Out = std::move(Val);
+      Changed = true;
+    }
+    return Cur.Out;
+  }
+
+  ProblemTy &Problem;
+  const i_t &ICF;
+  const SummaryTable &Summaries;
+  std::map<std::pair<f_t, n_t>, std::deque<Entry>> Tab;
+  std::size_t CurPass = 0;
+  bool Changed = false;
+};
+
+} // namespace elimination
+
+#endif // DATAFLOW_APA_SOLVER_MODULARINTERSUMMARYINTERPRETER_H_

--- a/include/Dataflow/APA/Solver/ModularInterSummarySolver.h
+++ b/include/Dataflow/APA/Solver/ModularInterSummarySolver.h
@@ -1,0 +1,297 @@
+#ifndef DATAFLOW_APA_SOLVER_MODULARINTERSUMMARYSOLVER_H_
+#define DATAFLOW_APA_SOLVER_MODULARINTERSUMMARYSOLVER_H_
+
+#include "Dataflow/APA/Core/InterProblem.h"
+#include "Dataflow/APA/EAN/DagStats.h"
+#include "Dataflow/APA/EAN/EAN.h"
+#include "Dataflow/APA/EAN/Greedy.h"
+#include "Dataflow/APA/Solver/CallGraphSCC.h"
+#include "Dataflow/APA/Solver/InterSummaryTransfer.h"
+#include "Dataflow/APA/Solver/PathSummaryEquationSolver.h"
+#include "Dataflow/ControlFlow/FlowDirection.h"
+
+#include <chrono>
+#include <cstddef>
+#include <map>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace elimination {
+
+// Modular interprocedural summary construction (E6, milestone 3).
+//
+// For every reachable non-opaque procedure P, build ONE entry->exit
+// path-expression summary S_P over P's own CFG, where call sites are turned
+// into symbolic `SummaryCall(callsite, callee, retsite)` atoms rather than
+// inlining the callee body. This is what makes the construction modular and
+// linear in program size: each summary is solved on P's CFG (bounded), never on
+// the whole-program x context product that makes the monolithic
+// ForwardInterSummarySolver blow up (root causes R1/R2).
+//
+// Recursion is NOT handled here: a SummaryCall to a same-team procedure is an
+// opaque placeholder. Closing recursive teams is an interpretation-time fixpoint
+// (milestone 4), guided by the reverse-topological order and `recursive` flag
+// carried in the returned CallGraphSCCResult.
+//
+// Reuse: per-procedure summaries are solved with PathSummaryEquationSolver over
+// atom_t (which already handles intra loops via star), NOT the intra
+// StateEliminationSolver (that engine is bound to transfer_t atoms and has no
+// notion of call sites).
+template <typename AnalysisDomainTy> class ModularInterSummaryBuilder final {
+public:
+  using ProblemTy = InterEliminationProblem<AnalysisDomainTy>;
+  using n_t = typename AnalysisDomainTy::n_t;
+  using f_t = typename AnalysisDomainTy::f_t;
+  using i_t = typename AnalysisDomainTy::i_t;
+  using atom_t = InterSummaryTransferAtom<AnalysisDomainTy>;
+  using graph_t = PathSummaryEquationGraph<n_t, atom_t>;
+  using expr_ref_t = typename graph_t::expr_ref_t;
+
+  struct ProcSummary final {
+    // entry->exit summary (union over the procedure's exit points). Null if the
+    // procedure has no reachable exit expression.
+    expr_ref_t exit;
+    // entry->node expression for every instruction, for interpretation (IN).
+    std::map<n_t, expr_ref_t> perNode;
+  };
+
+  using SummaryTable = std::unordered_map<f_t, ProcSummary>;
+
+  struct Result final {
+    SummaryTable summaries;
+    CallGraphSCCResult<f_t> callGraph; // reverse-topo order + recursive flags
+    // Aggregated per-procedure diagnostics (D4). Structural stats of the union
+    // of every procedure's summary batch, before/after per-procedure EAN, plus
+    // equation-graph totals and stage timings. summaryBefore == summaryAfter
+    // when no post-pass ran, so a single modular run yields the Default<->EAN
+    // node reduction directly (mirrors ForwardInterSummarySolver's Table VI/VII).
+    ean::DagStats summaryBefore;
+    ean::DagStats summaryAfter;
+    std::size_t equationNodeCount = 0;
+    std::size_t equationEdgeCount = 0;
+    std::size_t sccCount = 0;
+    std::size_t cyclicSccCount = 0;
+    std::size_t genTimeUs = 0;  // build + solve every per-procedure equation graph
+    std::size_t normTimeUs = 0; // per-procedure EAN/Greedy optimization (0 if off)
+  };
+
+  ModularInterSummaryBuilder(ProblemTy &Problem, const i_t &ICF,
+                             PathSummaryEquationOptions Options = {})
+      : Problem(Problem), ICF(ICF), Options(Options) {}
+
+  // Build summaries for every non-opaque procedure reachable from Entries.
+  Result build(const std::vector<f_t> &Entries) {
+    Result Out;
+    BatchBefore.clear();
+    BatchAfter.clear();
+    CallGraphSCCBuilder<n_t, f_t, i_t> CG(ICF);
+    Out.callGraph = CG.build(Entries);
+    for (const auto &Comp : Out.callGraph.order) {
+      for (const auto &P : Comp.procs) {
+        Out.summaries.emplace(P, buildProcedureSummary(P, Out));
+      }
+    }
+    // Aggregate structural stats over the union of all per-procedure batches.
+    // computeDagStats walks by pointer identity, so nodes from distinct
+    // per-procedure factories are (correctly) counted as distinct.
+    Out.summaryBefore = ean::computeDagStats<atom_t>(BatchBefore);
+    Out.summaryAfter = ean::computeDagStats<atom_t>(BatchAfter);
+    Out.genTimeUs = GenTimeUs;
+    Out.normTimeUs = NormTimeUs;
+    GenTimeUs = 0;
+    NormTimeUs = 0;
+    return Out;
+  }
+
+private:
+  using Fwd = ::dataflow::controlflow::FlowDirection;
+
+  bool isOpaque(const f_t &F) const {
+    return ICF.getStartPointsOf(F).empty() || ICF.getExitPointsOf(F).empty();
+  }
+
+  // Build P's entry->exit summary over its own CFG. Call sites become symbolic
+  // SummaryCall atoms; normal edges become RawNormal atoms; the local
+  // call-to-return effect is the bypass edge, mirroring
+  // ForwardInterSummarySolver::discoverCallSuccessors but WITHOUT inlining the
+  // callee body.
+  // Build P's entry->exit summary over its own CFG. Call sites become symbolic
+  // SummaryCall atoms; normal edges become RawNormal atoms; the local
+  // call-to-return effect is the bypass edge, mirroring
+  // ForwardInterSummarySolver::discoverCallSuccessors but WITHOUT inlining the
+  // callee body. Diagnostics (equation-graph totals, timings) accumulate into
+  // Out; the D4 per-procedure post-pass runs before the summary is returned.
+  ProcSummary buildProcedureSummary(const f_t &P, Result &Out) {
+    ProcSummary S;
+    graph_t Graph;
+    auto &E = Graph.exprs();
+
+    const auto Starts = ICF.getStartPointsOf(P);
+    if (Starts.empty()) {
+      return S;
+    }
+    // Seed every entry with identity so the forward solve yields entry->node.
+    for (const auto &St : Starts) {
+      if (St != n_t{}) {
+        Graph.setBase(St, E.one());
+      }
+    }
+
+    for (const auto &U : ICF.getAllInstructionsOf(P)) {
+      if (U == n_t{}) {
+        continue;
+      }
+      if (ICF.isCallSite(U)) {
+        addCallEdges(Graph, U);
+      } else {
+        for (const auto &V : ICF.getSuccsOf(U, Fwd::Forward)) {
+          if (V == n_t{}) {
+            continue;
+          }
+          Graph.addEdge(U, V, E.atom(atom_t::rawNormal(Problem.edgeTransfer(U, V))));
+        }
+      }
+    }
+
+    PathSummaryEquationOptions Opts;
+    Opts.Direction = PathSummaryEquationDirection::ForwardPath;
+    const auto GenStart = std::chrono::steady_clock::now();
+    PathSummaryEquationSolver<n_t, atom_t> Solver(Graph, Opts);
+    auto Solved = Solver.solve();
+    GenTimeUs += static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - GenStart)
+            .count());
+
+    const auto &Diag = Solved.diagnostics();
+    Out.equationNodeCount += Diag.node_count;
+    Out.equationEdgeCount += Diag.edge_count;
+    Out.sccCount += Diag.scc_count;
+    Out.cyclicSccCount += Diag.cyclic_scc_count;
+
+    for (const auto &KV : Solved.summaries()) {
+      S.perNode.emplace(KV.first, KV.second);
+    }
+    // S_P = union of entry->exit expressions over all exit points.
+    for (const auto &Exit : ICF.getExitPointsOf(P)) {
+      auto It = S.perNode.find(Exit);
+      if (It == S.perNode.end()) {
+        continue;
+      }
+      S.exit = S.exit ? E.unite(S.exit, It->second) : It->second;
+    }
+
+    // D4: optionally optimize THIS procedure's summary batch on its own small
+    // graph/factory, then interpretation reads the cheaper equivalent forms.
+    applyProcedurePostPass(Graph, S);
+    return S;
+  }
+
+  // Per-procedure EAN/Greedy post-pass (D4). Optimizes the batch of {every
+  // entry->node expression, the entry->exit expression} for one procedure as a
+  // single forest so cross-root sharing within the procedure is captured. The
+  // SummaryCall/callToRet atoms are opaque leaves to EAN (it never rewrites
+  // through them), so callee references survive untouched. No-op unless
+  // Options.EAN enables a pass; on any shape mismatch the original batch is kept
+  // (root preservation, I3). Every root (pre- and post-pass) is recorded into
+  // the builder-wide batches so build() can report the aggregate node reduction.
+  void applyProcedurePostPass(graph_t &Graph, ProcSummary &S) {
+    std::vector<n_t> Keys;
+    std::vector<expr_ref_t> Roots;
+    Keys.reserve(S.perNode.size());
+    Roots.reserve(S.perNode.size() + 1);
+    for (auto &KV : S.perNode) {
+      Keys.push_back(KV.first);
+      Roots.push_back(KV.second);
+    }
+    const bool HaveExit = static_cast<bool>(S.exit);
+    if (HaveExit) {
+      Roots.push_back(S.exit);
+    }
+    for (const auto &R : Roots) {
+      BatchBefore.push_back(R);
+    }
+
+    const auto &EAN = Options.EAN;
+    if (!EAN.EnableEAN && !EAN.EnableGreedy) {
+      for (const auto &R : Roots) {
+        BatchAfter.push_back(R); // baseline: after == before
+      }
+      return;
+    }
+
+    const auto NormStart = std::chrono::steady_clock::now();
+    std::vector<expr_ref_t> Optimized;
+    if (EAN.EnableEAN) {
+      ean::ExtractOptions EO = EAN.EANExtract;
+      EO.gateMinNodes = EAN.EANMinNodes;
+      EO.monotoneGuard = EAN.EANMonotone;
+      Optimized = ean::ean<atom_t>(Roots, EAN.EANLaws, EAN.EANCost,
+                                   EAN.EANBudget, Graph.exprs(), nullptr, EO);
+    } else {
+      Optimized = greedySimplify<atom_t>(Roots, Graph.exprs());
+    }
+    NormTimeUs += static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - NormStart)
+            .count());
+
+    if (Optimized.size() != Roots.size()) {
+      for (const auto &R : Roots) {
+        BatchAfter.push_back(R); // I3 fallback: keep the original batch
+      }
+      return;
+    }
+    for (std::size_t I = 0; I < Keys.size(); ++I) {
+      S.perNode[Keys[I]] = Optimized[I];
+    }
+    if (HaveExit) {
+      S.exit = Optimized.back();
+    }
+    for (const auto &R : Optimized) {
+      BatchAfter.push_back(R);
+    }
+  }
+
+  // Mirror ForwardInterSummarySolver::discoverCallSuccessors, but replace the
+  // callee-body edges with a single symbolic SummaryCall per non-opaque callee.
+  void addCallEdges(graph_t &Graph, const n_t &CallSite) {
+    auto &E = Graph.exprs();
+    const auto Callees = ICF.getCalleesOfCallAt(CallSite);
+    for (const auto &RetSite : ICF.getReturnSitesOfCallAt(CallSite)) {
+      if (RetSite == n_t{}) {
+        continue;
+      }
+      const auto Transfer = Problem.edgeTransfer(CallSite, RetSite);
+      auto Bypass = E.atom(atom_t::rawNormal(Transfer));
+      if (Problem.transferSuccessor(Transfer) != n_t{}) {
+        Bypass = E.concat(
+            Bypass, E.atom(atom_t::callToRet(CallSite, RetSite, Callees)));
+      }
+      Graph.addEdge(CallSite, RetSite, Bypass);
+
+      for (const auto &Callee : Callees) {
+        if (isOpaque(Callee)) {
+          continue; // external: only the bypass edge, no summary
+        }
+        Graph.addEdge(CallSite, RetSite,
+                      E.atom(atom_t::summaryCall(CallSite, Callee, RetSite)));
+      }
+    }
+  }
+
+  ProblemTy &Problem;
+  const i_t &ICF;
+  PathSummaryEquationOptions Options;
+  // Union of every procedure's summary roots (entry->node exprs + entry->exit),
+  // captured pre- and post- the D4 post-pass, for aggregate DagStats reporting.
+  std::vector<expr_ref_t> BatchBefore;
+  std::vector<expr_ref_t> BatchAfter;
+  std::size_t GenTimeUs = 0;
+  std::size_t NormTimeUs = 0;
+};
+
+} // namespace elimination
+
+#endif // DATAFLOW_APA_SOLVER_MODULARINTERSUMMARYSOLVER_H_

--- a/include/Dataflow/APA/Solver/PathSummaryEquationSolver.h
+++ b/include/Dataflow/APA/Solver/PathSummaryEquationSolver.h
@@ -1,6 +1,7 @@
 #ifndef DATAFLOW_APA_SOLVER_PATHSUMMARYEQUATIONSOLVER_H_
 #define DATAFLOW_APA_SOLVER_PATHSUMMARYEQUATIONSOLVER_H_
 
+#include "Dataflow/APA/Core/Options.h"
 #include "Dataflow/APA/Core/PathExpr.h"
 
 #include <algorithm>
@@ -89,6 +90,10 @@ enum class PathSummaryEquationDirection {
 struct PathSummaryEquationOptions final {
   PathSummaryEquationDirection Direction =
       PathSummaryEquationDirection::DependencyPrefix;
+  // EAN/Greedy post-optimization of the solved summary batch, applied by
+  // ForwardInterSummarySolver between summary solving and interpretation.
+  // Default is a no-op pass, so the interprocedural baseline is unchanged.
+  InterEANOptions EAN = {};
 };
 
 struct PathSummaryEquationDiagnostics final {
@@ -109,6 +114,11 @@ public:
   }
 
   const std::map<KeyT, expr_ref_t> &summaries() const { return Summaries; }
+  // Non-const access so a post-solve optimization pass (EAN/Greedy in
+  // ForwardInterSummarySolver) can replace each context's summary expression
+  // in place with a semantically-equivalent, cost-minimized form before
+  // interpretation. Keys are never added or removed through this handle.
+  std::map<KeyT, expr_ref_t> &summaries() { return Summaries; }
   const PathSummaryEquationDiagnostics &diagnostics() const {
     return Diagnostics;
   }
@@ -380,7 +390,20 @@ private:
     SummaryByNode[Node] = forwardBaseForNode(Node);
   }
 
+  // Dense cyclic SCCs use Floyd--Warshall; large SCCs above this node count use
+  // sparse min-fill Gaussian elimination (R2-intra: the dense O(N^3) closure
+  // dominates on big cyclic control-flow regions, e.g. a 152-node component).
+  static constexpr std::size_t kDenseCyclicThreshold = 16;
+
   void solveForwardCyclicComponent(const Component &C) {
+    if (C.Nodes.size() <= kDenseCyclicThreshold) {
+      solveForwardCyclicComponentDense(C);
+    } else {
+      solveForwardCyclicComponentSparse(C);
+    }
+  }
+
+  void solveForwardCyclicComponentDense(const Component &C) {
     const std::size_t N = C.Nodes.size();
     std::unordered_map<std::size_t, std::size_t> LocalIndex;
     LocalIndex.reserve(N);
@@ -446,6 +469,163 @@ private:
         Summary = unite(Summary, concat(Base[I], Matrix[I][J]));
       }
       SummaryByNode[C.Nodes[J]] = Summary;
+    }
+  }
+
+  // Sparse forward cyclic solve: Gaussian (Lehmann/Tarjan) elimination of the
+  // left-linear system  X_v = base_v  U  U_{u->v} X_u . W[u][v],  choosing
+  // pivots by min-fill (min-degree tiebreak).  Eliminating v only rewrites its
+  // remaining predecessor x successor pairs, so a sparse SCC never materializes
+  // the dense N*N closure.  Value-equivalent to solveForwardCyclicComponentDense.
+  void solveForwardCyclicComponentSparse(const Component &C) {
+    const std::size_t N = C.Nodes.size();
+    std::unordered_map<std::size_t, std::size_t> LocalIndex;
+    LocalIndex.reserve(N);
+    for (std::size_t I = 0; I < N; ++I) {
+      LocalIndex.emplace(C.Nodes[I], I);
+    }
+
+    // Sparse adjacency over local indices: Succ[u][v] = Pred[v][u] = weight u->v.
+    std::vector<std::map<std::size_t, expr_ref_t>> Succ(N), Pred(N);
+    std::vector<expr_ref_t> Base(N);
+    for (std::size_t I = 0; I < N; ++I) {
+      Base[I] = forwardBaseForNode(C.Nodes[I]);
+      if (!Base[I]) {
+        Base[I] = zero();
+      }
+    }
+    auto addEdge = [&](std::size_t U, std::size_t V, const expr_ref_t &W) {
+      auto SIt = Succ[U].find(V);
+      if (SIt == Succ[U].end()) {
+        Succ[U].emplace(V, W);
+        Pred[V].emplace(U, W);
+      } else {
+        expr_ref_t Merged = unite(SIt->second, W);
+        SIt->second = Merged;
+        Pred[V][U] = Merged;
+      }
+    };
+    for (std::size_t I = 0; I < N; ++I) {
+      for (std::size_t EdgeId : OutEdges[C.Nodes[I]]) {
+        const auto &E = Graph.edges()[EdgeId];
+        auto It = LocalIndex.find(E.Target);
+        if (It == LocalIndex.end()) {
+          continue;
+        }
+        addEdge(I, It->second, E.Weight);
+      }
+    }
+
+    std::vector<bool> Elim(N, false);
+    std::vector<std::size_t> Order;
+    Order.reserve(N);
+    std::vector<expr_ref_t> RecStar(N), RecBase(N);
+    std::vector<std::vector<std::pair<std::size_t, expr_ref_t>>> RecPreds(N);
+
+    for (std::size_t Step = 0; Step < N; ++Step) {
+      // Select the remaining pivot with the fewest fill edges (min-degree tie).
+      std::size_t Pivot = N;
+      std::size_t BestFill = 0, BestDeg = 0;
+      for (std::size_t V = 0; V < N; ++V) {
+        if (Elim[V]) {
+          continue;
+        }
+        std::vector<std::size_t> Ps, Ss;
+        for (const auto &PR : Pred[V]) {
+          if (PR.first != V && !Elim[PR.first]) {
+            Ps.push_back(PR.first);
+          }
+        }
+        for (const auto &SC : Succ[V]) {
+          if (SC.first != V && !Elim[SC.first]) {
+            Ss.push_back(SC.first);
+          }
+        }
+        const std::size_t Deg = Ps.size() + Ss.size();
+        std::size_t Fill = 0;
+        for (std::size_t U : Ps) {
+          for (std::size_t S : Ss) {
+            if (U != S && Succ[U].find(S) == Succ[U].end()) {
+              ++Fill;
+            }
+          }
+        }
+        if (Pivot == N || Fill < BestFill ||
+            (Fill == BestFill && Deg < BestDeg)) {
+          Pivot = V;
+          BestFill = Fill;
+          BestDeg = Deg;
+        }
+      }
+
+      const std::size_t V = Pivot;
+      auto SelfIt = Succ[V].find(V);
+      const expr_ref_t Wstar =
+          star(SelfIt == Succ[V].end() ? zero() : SelfIt->second);
+
+      // Record v's equation for back-substitution before splicing it out.
+      // X_v = (base_v  U  U_{u!=v} X_u . W[u][v]) . W[v][v]*.
+      RecStar[V] = Wstar;
+      RecBase[V] = Base[V];
+      std::vector<std::pair<std::size_t, expr_ref_t>> Preds, Succs;
+      for (const auto &PR : Pred[V]) {
+        if (PR.first != V && !Elim[PR.first]) {
+          Preds.push_back(PR);
+          RecPreds[V].push_back(PR);
+        }
+      }
+      for (const auto &SC : Succ[V]) {
+        if (SC.first != V && !Elim[SC.first]) {
+          Succs.push_back(SC);
+        }
+      }
+
+      // Fold v's base into successors: base_s U base_v . W[v][v]* . W[v][s].
+      if (!expr_factory_t::isZero(Base[V])) {
+        const expr_ref_t BaseLeft = concat(Base[V], Wstar);
+        for (const auto &SC : Succs) {
+          Base[SC.first] = unite(Base[SC.first], concat(BaseLeft, SC.second));
+        }
+      }
+
+      // Add fill edges u->s: W[u][s] U W[u][v] . W[v][v]* . W[v][s].
+      for (const auto &PR : Preds) {
+        const expr_ref_t Left = concat(PR.second, Wstar);
+        for (const auto &SC : Succs) {
+          addEdge(PR.first, SC.first, concat(Left, SC.second));
+        }
+      }
+
+      // Splice v out of the remaining graph.
+      for (const auto &PR : Pred[V]) {
+        if (PR.first != V) {
+          Succ[PR.first].erase(V);
+        }
+      }
+      for (const auto &SC : Succ[V]) {
+        if (SC.first != V) {
+          Pred[SC.first].erase(V);
+        }
+      }
+      Succ[V].clear();
+      Pred[V].clear();
+      Elim[V] = true;
+      Order.push_back(V);
+    }
+
+    // Back-substitute in reverse elimination order: every recorded predecessor
+    // was eliminated after v, so its solution X[u] is already available here.
+    std::vector<expr_ref_t> X(N);
+    for (auto It = Order.rbegin(); It != Order.rend(); ++It) {
+      const std::size_t V = *It;
+      expr_ref_t Acc = RecBase[V];
+      for (const auto &PR : RecPreds[V]) {
+        Acc = unite(Acc, concat(X[PR.first], PR.second));
+      }
+      X[V] = concat(Acc, RecStar[V]);
+    }
+    for (std::size_t I = 0; I < N; ++I) {
+      SummaryByNode[C.Nodes[I]] = X[I];
     }
   }
 

--- a/include/Dataflow/APA/Solver/Solver.h
+++ b/include/Dataflow/APA/Solver/Solver.h
@@ -34,6 +34,20 @@ public:
   // reducibility assumptions do not hold; in that case we transparently fall
   // back to the generic state-elimination engine.
   SolveStatus solve() {
+    SolveStatus S = solveImpl();
+    // Run a post-optimization pass once after a successful solve, before results
+    // are read. EAN and Greedy are mutually exclusive (EAN takes precedence).
+    if (S != SolveStatus::InvalidProblem) {
+      if (Opts.EnableEAN) {
+        Ctx.applyEAN();
+      } else if (Opts.EnableGreedy) {
+        Ctx.applyGreedy();
+      }
+    }
+    return S;
+  }
+
+  SolveStatus solveImpl() {
     UsedADT = false;
     LastStatus = SolveStatus::Ok;
     Ctx.Diagnostics = {};

--- a/include/Dataflow/APA/Solver/SolverContext.h
+++ b/include/Dataflow/APA/Solver/SolverContext.h
@@ -5,9 +5,12 @@
 #include "Dataflow/APA/Core/PathExpr.h"
 #include "Dataflow/APA/Core/Problem.h"
 #include "Dataflow/APA/Core/Result.h"
+#include "Dataflow/APA/EAN/EAN.h"
+#include "Dataflow/APA/EAN/Greedy.h"
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -777,6 +780,103 @@ public:
     auto It = Index.find(N);
     assert(It != Index.end());
     return It->second;
+  }
+
+  // EAN post-optimization: replace each summary's path expression with a
+  // reuse-aware, cost-minimized equivalent (as a batch), then interpret the
+  // optimized forms. Runs only when Opts.EnableEAN. Results are preserved
+  // because EAN preserves semantics under the client's declared law profile
+  // (the default profile is universally safe); on any internal resource failure
+  // ean() falls back to the original batch (root preservation, I3).
+  void applyEAN() {
+    const result_t &ConstResults = Results;
+    std::vector<n_t> Ns;
+    std::vector<expr_ref_t> Roots;
+    for (const auto &N : Problem.nodes()) {
+      expr_ref_t E = ConstResults.ExprTo(N);
+      if (!E) {
+        continue; // node has no constructed summary
+      }
+      Ns.push_back(N);
+      Roots.push_back(std::move(E));
+    }
+    if (Roots.empty()) {
+      return;
+    }
+    ean::ExtractOptions EO = Opts.EANExtract;
+    EO.gateMinNodes = Opts.EANMinNodes;
+    EO.monotoneGuard = Opts.EANMonotone;
+    const auto NormStart = std::chrono::steady_clock::now();
+    auto Optimized =
+        ean::ean<transfer_t>(Roots, Opts.EANLaws, Opts.EANCost, Opts.EANBudget,
+                             Exprs, nullptr, EO);
+    Diagnostics.norm_time_us += static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - NormStart)
+            .count());
+    const auto Init = Problem.initialFact();
+    const std::size_t Reps = Opts.InterpRepeat ? Opts.InterpRepeat : 1;
+    const auto InterpStart = std::chrono::steady_clock::now();
+    for (std::size_t i = 0; i < Ns.size(); ++i) {
+      Results.ExprTo(Ns[i]) = Optimized[i];
+      if (Opts.InterpMemo) {
+        continue; // client fills IN via its memoizing interpreter
+      }
+      fact_t V = eval(Optimized[i], Init);
+      for (std::size_t r = 1; r < Reps; ++r) {
+        V = eval(Optimized[i], Init); // amortization measurement (RQ2)
+      }
+      Results.IN(Ns[i]) = std::move(V);
+    }
+    Diagnostics.interp_time_us += static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - InterpStart)
+            .count());
+  }
+
+  // Greedy post-optimization (paper's "Greedy" config): a single deterministic
+  // prefix-factorization pass over the summary batch, then re-interpret. Like
+  // applyEAN but with greedySimplify instead of the e-graph optimizer. Runs only
+  // when Opts.EnableGreedy (and not EnableEAN). Semantics-preserving.
+  void applyGreedy() {
+    const result_t &ConstResults = Results;
+    std::vector<n_t> Ns;
+    std::vector<expr_ref_t> Roots;
+    for (const auto &N : Problem.nodes()) {
+      expr_ref_t E = ConstResults.ExprTo(N);
+      if (!E) {
+        continue;
+      }
+      Ns.push_back(N);
+      Roots.push_back(std::move(E));
+    }
+    if (Roots.empty()) {
+      return;
+    }
+    const auto NormStart = std::chrono::steady_clock::now();
+    auto Simplified = greedySimplify<transfer_t>(Roots, Exprs);
+    Diagnostics.norm_time_us += static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - NormStart)
+            .count());
+    const auto Init = Problem.initialFact();
+    const std::size_t Reps = Opts.InterpRepeat ? Opts.InterpRepeat : 1;
+    const auto InterpStart = std::chrono::steady_clock::now();
+    for (std::size_t i = 0; i < Ns.size(); ++i) {
+      Results.ExprTo(Ns[i]) = Simplified[i];
+      if (Opts.InterpMemo) {
+        continue; // client fills IN via its memoizing interpreter
+      }
+      fact_t V = eval(Simplified[i], Init);
+      for (std::size_t r = 1; r < Reps; ++r) {
+        V = eval(Simplified[i], Init);
+      }
+      Results.IN(Ns[i]) = std::move(V);
+    }
+    Diagnostics.interp_time_us += static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - InterpStart)
+            .count());
   }
 
   const ProblemTy &Problem;

--- a/include/Dataflow/APA/Solver/StateEliminationSolver.h
+++ b/include/Dataflow/APA/Solver/StateEliminationSolver.h
@@ -1,10 +1,37 @@
 #ifndef DATAFLOW_APA_ENGINES_STATEELIMINATIONSOLVER_H_
 #define DATAFLOW_APA_ENGINES_STATEELIMINATIONSOLVER_H_
 
+#include "Dataflow/APA/EAN/DagStats.h"
+#include "Dataflow/APA/Solver/EliminationOrder.h"
 #include "Dataflow/APA/Solver/SolverContext.h"
+
+#include <chrono>
 
 namespace elimination {
 namespace detail {
+
+// Build the boolean elimination graph from the current matrix's off-diagonal
+// nonzeros (direct CFG edges at this point). Self-loops are the diagonal
+// (always one()) and are intentionally excluded — they do not affect the
+// predecessor–successor product.
+template <typename AnalysisDomainTy>
+order::EliminationGraph buildEliminationGraph(
+    const IntraEliminationSolverContext<AnalysisDomainTy> &Ctx) {
+  using Context = IntraEliminationSolverContext<AnalysisDomainTy>;
+  const auto N = Ctx.Nodes.size();
+  order::EliminationGraph G(N);
+  for (std::size_t i = 0; i < N; ++i) {
+    for (std::size_t j = 0; j < N; ++j) {
+      if (i == j) {
+        continue;
+      }
+      if (!Context::expr_factory_t::isZero(Ctx.Matrix[i][j])) {
+        G.addEdge(i, j);
+      }
+    }
+  }
+  return G;
+}
 
 // Generic Floyd-Warshall-style elimination over the full CFG. This engine
 // makes no reducibility assumptions and therefore serves as the baseline
@@ -14,6 +41,14 @@ std::vector<std::size_t> getStateEliminationOrder(
     const IntraEliminationSolverContext<AnalysisTypesT> &Ctx) {
   using Context = IntraEliminationSolverContext<AnalysisTypesT>;
   const auto N = Ctx.Nodes.size();
+
+  // Cost-aware policy: greedy minimum-product order over the elimination graph.
+  // Fully replaces the baseline order (including the reducible reverse-topo
+  // path). The final all-pairs result is invariant to pivot order.
+  if (Ctx.Opts.Ordering == OrderingPolicy::CostAware) {
+    return order::computeCostAwareOrder(buildEliminationGraph(Ctx));
+  }
+
   std::vector<std::size_t> Order(N);
   const auto *R =
       dynamic_cast<const typename Context::ReducibleProblemTy *>(&Ctx.Problem);
@@ -83,7 +118,29 @@ void eliminateStateIntermediates(
   std::vector<typename Context::expr_ref_t> ColK(N);
   std::vector<typename Context::expr_ref_t> RowK(N);
 
+  // Opt-in RQ3 instrumentation: peak unique DAG nodes across the whole matrix.
+  const bool Measure = Ctx.Opts.MeasurePeakNodes;
+  auto measurePeak = [&]() {
+    if (!Measure) {
+      return;
+    }
+    std::vector<typename Context::expr_ref_t> Live;
+    Live.reserve(N * N);
+    for (std::size_t i = 0; i < N; ++i) {
+      for (std::size_t j = 0; j < N; ++j) {
+        if (!Context::expr_factory_t::isZero(Ctx.Matrix[i][j])) {
+          Live.push_back(Ctx.Matrix[i][j]);
+        }
+      }
+    }
+    const std::size_t nodes = ean::computeDagStats<transfer_t>(Live).uniqueNodes;
+    if (nodes > Ctx.Diagnostics.peak_matrix_nodes) {
+      Ctx.Diagnostics.peak_matrix_nodes = nodes;
+    }
+  };
+
   const auto Order = getStateEliminationOrder(Ctx);
+  measurePeak(); // initial (direct-edge) matrix
   for (std::size_t ki = 0; ki < N; ++ki) {
     const std::size_t k = Order[ki];
     // Snapshot row/column k before mutating the matrix. This mirrors the
@@ -110,6 +167,7 @@ void eliminateStateIntermediates(
         Ctx.Matrix[i][j] = Ctx.Exprs.unite(Ctx.Matrix[i][j], Via);
       }
     }
+    measurePeak(); // after eliminating k
   }
 }
 
@@ -129,21 +187,41 @@ bool materializeStateResults(
   const auto EntryIdx = EntryIt->second;
 
   const auto Init = Ctx.Problem.initialFact();
+  const std::size_t Reps = Ctx.Opts.InterpRepeat ? Ctx.Opts.InterpRepeat : 1;
+  const auto InterpStart = std::chrono::steady_clock::now();
   for (std::size_t j = 0; j < Ctx.Nodes.size(); ++j) {
     const auto &N = Ctx.Nodes[j];
     // Each remaining matrix entry summarizes all paths from entry to N.
     auto E = Ctx.Matrix[EntryIdx][j];
     Ctx.Results.ExprTo(N) = E;
-    Ctx.Results.IN(N) = Ctx.eval(E, Init);
+    // Skip the interpretation when EAN or Greedy will re-optimize and
+    // re-evaluate the whole batch afterwards (avoids a wasted eval), or when a
+    // memoizing client interpreter (InterpMemo) will fill IN facts itself.
+    if (!Ctx.Opts.EnableEAN && !Ctx.Opts.EnableGreedy && !Ctx.Opts.InterpMemo) {
+      typename Context::fact_t V = Ctx.eval(E, Init);
+      for (std::size_t r = 1; r < Reps; ++r) {
+        V = Ctx.eval(E, Init); // amortization measurement (RQ2)
+      }
+      Ctx.Results.IN(N) = std::move(V);
+    }
   }
+  Ctx.Diagnostics.interp_time_us += static_cast<std::size_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - InterpStart)
+          .count());
   return true;
 }
 
 template <typename AnalysisTypesT>
 bool solveStateElimination(
     IntraEliminationSolverContext<AnalysisTypesT> &Ctx) {
+  const auto GenStart = std::chrono::steady_clock::now();
   buildStateEliminationMatrix(Ctx);
   eliminateStateIntermediates(Ctx);
+  Ctx.Diagnostics.gen_time_us += static_cast<std::size_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - GenStart)
+          .count());
   return materializeStateResults(Ctx);
 }
 

--- a/include/Solvers/EGraph/Extract.h
+++ b/include/Solvers/EGraph/Extract.h
@@ -2,10 +2,12 @@
 
 #include "Solvers/EGraph/EGraph.h"
 
+#include <deque>
 #include <functional>
 #include <limits>
 #include <optional>
 #include <type_traits>
+#include <unordered_set>
 
 #include <llvm/ADT/SmallVector.h>
 

--- a/lib/Dataflow/APA/Analyses/Inter/Reachability.cpp
+++ b/lib/Dataflow/APA/Analyses/Inter/Reachability.cpp
@@ -1,6 +1,7 @@
 #include "Dataflow/APA/LLVM/InterProblem.h"
 #include "Dataflow/APA/Analyses/Inter/Reachability.h"
 #include "Dataflow/APA/Solver/ForwardInterSummarySolver.h"
+#include "Dataflow/APA/Solver/ModularInterSummaryDriver.h"
 
 namespace elimination {
 namespace {
@@ -105,6 +106,31 @@ runInterSummaryElimReachable(llvm::Function *Entry,
   }
   Out.setSolveStatus(Status);
   Out.setSummarySolveDiagnostics(Solver.resultDiagnostics());
+  return Out;
+}
+
+InterReachableResult
+runModularInterReachable(llvm::Function *Entry,
+                         const dataflow::controlflow::InterCFG *ICF,
+                         PathSummaryEquationOptions Options) {
+  InterReachableResult Out;
+  if (Entry == nullptr || Entry->isDeclaration()) {
+    return Out;
+  }
+
+  std::unique_ptr<dataflow::controlflow::LLVMInterCFG> OwnedICF;
+  if (ICF == nullptr) {
+    OwnedICF = std::make_unique<dataflow::controlflow::LLVMInterCFG>(
+        Entry != nullptr ? Entry->getParent() : nullptr);
+    ICF = OwnedICF.get();
+  }
+
+  InterElimReachableProblem Problem(Entry, ICF);
+  ModularInterSummaryDriver<InterReachabilityAnalysisTypes,
+                            kDefaultInterElimReachabilityCallStringLength>
+      Driver(Problem, *ICF, Options);
+  // Reachability seed: the entry procedure starts reachable (fact = true).
+  Out = Driver.solve(std::vector<llvm::Function *>{Entry}, /*InitialFact=*/true);
   return Out;
 }
 

--- a/lib/Dataflow/APA/Analyses/Intra/IntraAffineEqualities.cpp
+++ b/lib/Dataflow/APA/Analyses/Intra/IntraAffineEqualities.cpp
@@ -1,0 +1,319 @@
+#include "Dataflow/APA/Analyses/Intra/IntraAffineEqualities.h"
+
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instructions.h"
+
+#include "Dataflow/APA/Domains/AffineRelationDomain.h"
+#include "Dataflow/APA/Solver/Solver.h"
+
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace elimination {
+namespace {
+
+using D = AffineRelationDomain;
+
+// An integer scalar the modular (Z/2^w) domain can represent.
+bool isCandidate(const llvm::Value *V) {
+  if (V == nullptr) {
+    return false;
+  }
+  auto *IntTy = llvm::dyn_cast<llvm::IntegerType>(V->getType());
+  return IntTy != nullptr && IntTy->getBitWidth() >= 1 &&
+         IntTy->getBitWidth() <= 64;
+}
+
+// The affine-relation domain does linear algebra over a single ring Z/2^w;
+// mixing bit-widths yields imprecise/bottom results. So we track scalars of one
+// dominant width only (most frequent; ties broken toward the wider). Values of
+// other widths become untracked (their definitions havoc/identity — sound).
+unsigned dominantWidth(llvm::Function &F) {
+  std::map<unsigned, unsigned> Counts;
+  auto Consider = [&](const llvm::Value *V) {
+    if (isCandidate(V)) {
+      ++Counts[llvm::cast<llvm::IntegerType>(V->getType())->getBitWidth()];
+    }
+  };
+  for (auto &Arg : F.args()) {
+    Consider(&Arg);
+  }
+  for (auto &I : llvm::instructions(F)) {
+    Consider(&I);
+  }
+  unsigned Best = 0, BestCount = 0;
+  for (const auto &[W, C] : Counts) {
+    if (C > BestCount || (C == BestCount && W > Best)) {
+      Best = W;
+      BestCount = C;
+    }
+  }
+  return Best;
+}
+
+// Build the per-function vocabulary of tracked scalars (single dominant width):
+// arguments first, then instruction results (also recorded as locals). The
+// domain is configured from a pointer to this, so it must outlive the solve.
+AffineRelationVocabulary buildVocabulary(llvm::Function &F) {
+  const unsigned Width = dominantWidth(F);
+  AffineRelationVocabulary Vocab;
+  auto Add = [&](const llvm::Value *V) {
+    if (!isCandidate(V) ||
+        llvm::cast<llvm::IntegerType>(V->getType())->getBitWidth() != Width ||
+        Vocab.indices.count(V)) {
+      return;
+    }
+    const unsigned Idx = static_cast<unsigned>(Vocab.values.size());
+    Vocab.indices.emplace(V, Idx);
+    Vocab.actualBitWidths.emplace(V, Width);
+    Vocab.values.push_back(V);
+  };
+  if (Width != 0) {
+    for (auto &Arg : F.args()) {
+      Add(&Arg);
+    }
+    for (auto &I : llvm::instructions(F)) {
+      Add(&I);
+    }
+  }
+  return Vocab;
+}
+
+// Fold a binary operator into (constant, terms) over its DIRECT operands only
+// (no recursive inlining — operands are vocabulary variables carrying their own
+// transfers). Returns nullopt when the result is not affine (e.g. mul of two
+// variables, div, rem, bitwise ops), so the caller havocs the destination.
+// Membership uses the CONFIGURED vocabulary (D::isTrackedValue).
+struct AffineForm {
+  int64_t constant = 0;
+  std::vector<std::pair<const llvm::Value *, int64_t>> terms;
+};
+
+std::optional<AffineForm> foldBinary(const llvm::BinaryOperator &BO) {
+  const llvm::Value *A = BO.getOperand(0);
+  const llvm::Value *B = BO.getOperand(1);
+  auto *CA = llvm::dyn_cast<llvm::ConstantInt>(A);
+  auto *CB = llvm::dyn_cast<llvm::ConstantInt>(B);
+
+  auto addOperand = [](AffineForm &F, const llvm::Value *V,
+                       const llvm::ConstantInt *C, int64_t Sign) -> bool {
+    if (C != nullptr) {
+      F.constant += Sign * C->getSExtValue();
+      return true;
+    }
+    if (D::isTrackedValue(V)) {
+      F.terms.emplace_back(V, Sign);
+      return true;
+    }
+    return false; // untracked non-constant operand -> not affine
+  };
+
+  AffineForm Form;
+  switch (BO.getOpcode()) {
+  case llvm::Instruction::Add:
+    if (addOperand(Form, A, CA, +1) && addOperand(Form, B, CB, +1)) {
+      return Form;
+    }
+    return std::nullopt;
+  case llvm::Instruction::Sub:
+    if (addOperand(Form, A, CA, +1) && addOperand(Form, B, CB, -1)) {
+      return Form;
+    }
+    return std::nullopt;
+  case llvm::Instruction::Mul: {
+    // Affine only when at least one factor is constant.
+    if (CA != nullptr && CB != nullptr) {
+      Form.constant = CA->getSExtValue() * CB->getSExtValue();
+      return Form;
+    }
+    if (CA != nullptr && D::isTrackedValue(B)) {
+      Form.terms.emplace_back(B, CA->getSExtValue());
+      return Form;
+    }
+    if (CB != nullptr && D::isTrackedValue(A)) {
+      Form.terms.emplace_back(A, CB->getSExtValue());
+      return Form;
+    }
+    return std::nullopt;
+  }
+  default:
+    return std::nullopt;
+  }
+}
+
+// The affine transformer of a single instruction's execution. Instructions that
+// do not define a TRACKED value leave all tracked variables unchanged
+// (identity); a tracked definition is either an exact affine assignment or a
+// sound havoc (forget) of just that destination.
+AffineFact instructionTransfer(const llvm::Instruction &I) {
+  if (!D::isTrackedValue(&I)) {
+    return D::identity();
+  }
+  if (auto *BO = llvm::dyn_cast<llvm::BinaryOperator>(&I)) {
+    if (auto Form = foldBinary(*BO)) {
+      return D::makeAffineAssignment(&I, Form->constant, Form->terms);
+    }
+  }
+  return D::makeForget(&I);
+}
+
+// --- Memoizing (transformer-composition) interpreter --------------------------
+// Instead of the generic tree-walking eval (cost ∝ expanded tree, which blows
+// up on real affine functions), compute each unique path-expression DAG node's
+// transformer exactly once (memoized by Expr pointer) and combine bottom-up.
+// Cost ∝ unique DAG nodes. Because the affine domain is a Kleene algebra of
+// transformers and initialFact() is the compositional unit (identity), the node
+// transformer IS the IN relation, so IN(node) = T(ExprTo(node)) — identical to
+// the tree eval but without recomputing shared subexpressions.
+using ExprFactory = PathExprFactory<llvm::Instruction *>;
+using ExprRef = ExprFactory::Ref;
+using ExprNode = ExprFactory::Expr;
+using ExprKind = ExprFactory::Kind;
+
+// Reflexive-transitive closure transformer T* = 1 ⊕ T ⊕ T² ⊕ … , matching the
+// tree interpreter's Star fixpoint (X = 1 ⊕ T·X). Converges finitely for affine
+// relations (Howell normal form, bounded lattice height).
+AffineFact closureOf(const AffineFact &T, std::size_t Limit) {
+  AffineFact C = D::zero();
+  for (std::size_t i = 0; i < Limit; ++i) {
+    AffineFact Next = D::combine(D::identity(), D::extend(T, C));
+    if (D::equal(Next, C)) {
+      return C;
+    }
+    C = std::move(Next);
+  }
+  return C;
+}
+
+AffineFact memoTransfer(const ExprRef &E,
+                        std::unordered_map<const ExprNode *, AffineFact> &Memo,
+                        std::size_t Limit) {
+  if (!E) {
+    return D::zero();
+  }
+  auto It = Memo.find(E.get());
+  if (It != Memo.end()) {
+    return It->second;
+  }
+  // Children are computed into local copies BEFORE inserting into Memo (a
+  // recursive insert may rehash and invalidate references).
+  AffineFact R;
+  switch (E->K) {
+  case ExprKind::Zero:
+    R = D::zero();
+    break;
+  case ExprKind::One:
+    R = D::identity();
+    break;
+  case ExprKind::Atom:
+    R = instructionTransfer(**E->Transfer);
+    break;
+  case ExprKind::Union: {
+    AffineFact L = memoTransfer(E->L, Memo, Limit);
+    AffineFact Rr = memoTransfer(E->R, Memo, Limit);
+    R = D::combine(L, Rr);
+    break;
+  }
+  case ExprKind::Concat: {
+    AffineFact L = memoTransfer(E->L, Memo, Limit);
+    AffineFact Rr = memoTransfer(E->R, Memo, Limit);
+    R = D::extend(Rr, L); // apply L first, then R
+    break;
+  }
+  case ExprKind::Star:
+    R = closureOf(memoTransfer(E->L, Memo, Limit), Limit);
+    break;
+  }
+  Memo.emplace(E.get(), R);
+  return R;
+}
+
+// Fill every node's IN fact by memoized transformer evaluation of its optimized
+// path expression. One shared Memo across the whole batch → each unique DAG
+// node's transformer is computed once (cost ∝ unique nodes, not tree size).
+void memoInterpret(llvm::Function &F, AffineResult &Result, std::size_t Limit) {
+  std::unordered_map<const ExprNode *, AffineFact> Memo;
+  for (auto &I : llvm::instructions(F)) {
+    ExprRef E = Result.ExprTo(&I);
+    if (!E) {
+      continue;
+    }
+    Result.IN(&I) = memoTransfer(E, Memo, Limit);
+  }
+}
+
+class ElimAffineProblem : public LLVMIntraEliminationProblem<AffineFact> {
+public:
+  explicit ElimAffineProblem(llvm::Function *F)
+      : LLVMIntraEliminationProblem<AffineFact>(F) {}
+
+  AffineFact applyTransfer(const transfer_t &T,
+                           const AffineFact &In) const override {
+    if (T == nullptr) {
+      return In;
+    }
+    return D::extend(instructionTransfer(*T), In);
+  }
+
+  // CFG merge / path-expression Union: affine hull (join), NOT the domain's
+  // constraint-intersecting meet().
+  AffineFact join(const AffineFact &Lhs,
+                  const AffineFact &Rhs) const override {
+    return D::combine(Lhs, Rhs);
+  }
+
+  bool equal(const AffineFact &Lhs, const AffineFact &Rhs) const override {
+    return D::equal(Lhs, Rhs);
+  }
+
+  // Neutral element of the join (bottom).
+  AffineFact bottom() const override { return D::zero(); }
+
+  // Seed at entry before any transfer: the identity (diagonal) relation.
+  AffineFact initialFact() const override { return D::identity(); }
+};
+
+} // namespace
+
+AffineResult runIntraElimAffine(llvm::Function *F, EliminationOptions Opts) {
+  if (F == nullptr || F->isDeclaration()) {
+    return AffineResult{};
+  }
+
+  // The domain is parameterized by a static vocabulary singleton; configure it
+  // for this function and keep the vocabulary alive across the (synchronous)
+  // solve. Not thread-safe — one function at a time.
+  AffineRelationVocabulary Vocab = buildVocabulary(*F);
+  D::configure(&Vocab);
+
+  ElimAffineProblem Problem(F);
+  IntraEliminationSolver<LLVMAnalysisTypes<AffineFact>> Solver(Problem,
+                                                              Opts);
+  auto Status = Solver.solve();
+  auto Out = Solver.getResults();
+  auto Diag = Solver.getDiagnostics();
+  if (Opts.InterpMemo) {
+    // The generic engines skipped the tree interpreter (InterpMemo); fill IN
+    // facts here via the memoizing transformer interpreter over the (optimized)
+    // ExprTo batch, and record its time as the interpretation cost.
+    const auto MemoStart = std::chrono::steady_clock::now();
+    const std::size_t Limit =
+        Opts.MaxStarIterations ? Opts.MaxStarIterations : 100000;
+    memoInterpret(*F, Out, Limit);
+    Diag.interp_time_us += static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - MemoStart)
+            .count());
+  }
+  Out.setSolveMetadata(Status, Diag);
+  return Out;
+}
+
+} // namespace elimination

--- a/lib/Dataflow/APA/Analyses/Intra/Reachability.cpp
+++ b/lib/Dataflow/APA/Analyses/Intra/Reachability.cpp
@@ -1,5 +1,7 @@
 #include "Dataflow/APA/Analyses/Intra/Reachability.h"
 
+#include "Dataflow/APA/Baseline/TranslAPA/Driver.h"
+
 namespace elimination {
 namespace {
 
@@ -30,6 +32,52 @@ ReachableResult runIntraElimReachable(llvm::Function *F,
   auto Status = Solver.solve();
   auto Out = Solver.getResults();
   Out.setSolveMetadata(Status, Solver.getDiagnostics());
+  return Out;
+}
+
+namespace {
+// One-fact translator for the degenerate reachability lattice: the universe is
+// a single "reachable" bit and every atom is the identity transfer ({}, {}).
+struct ReachableTranslator {
+  unsigned universeSize() const { return 1; }
+  translapa::GenKillFact translate(llvm::Instruction *const & /*T*/) const {
+    return {llvm::BitVector(1, false), llvm::BitVector(1, false)};
+  }
+  llvm::BitVector toBits(const ReachableFact &R) const {
+    return llvm::BitVector(1, R);
+  }
+  ReachableFact fromBits(const llvm::BitVector &B) const { return B.test(0); }
+};
+} // namespace
+
+ReachableResult runIntraTranslApaReachable(llvm::Function *F,
+                                           EliminationOptions Opts) {
+  if (F == nullptr || F->isDeclaration()) {
+    return ReachableResult{};
+  }
+
+  // See IntraReachingDefinitions.cpp for the rationale: under EAN/Greedy the
+  // post-pass rewrites Results.ExprTo in place, so InterpMemo lets us fold the
+  // optimized DAG instead of paying a discarded generic eval.
+  if (Opts.EnableEAN || Opts.EnableGreedy) {
+    Opts.InterpMemo = true;
+  }
+
+  ElimReachableProblem Problem(F);
+  IntraEliminationSolver<LLVMAnalysisTypes<ReachableFact, ReachabilityDomain>>
+      Solver(Problem, Opts);
+  auto Status = Solver.solve();
+  auto Out = Solver.getResults();
+  auto Diag = Solver.getDiagnostics();
+
+  ReachableTranslator Tr;
+  auto TT =
+      translapa::foldFillGenKillTimed<
+          LLVMAnalysisTypes<ReachableFact, ReachabilityDomain>>(Problem, Out,
+                                                                Tr);
+  Diag.norm_time_us += TT.extract_us;
+  Diag.interp_time_us = TT.fold_us;
+  Out.setSolveMetadata(Status, Diag);
   return Out;
 }
 

--- a/lib/Dataflow/APA/Analyses/Intra/ReachingDefinitions.cpp
+++ b/lib/Dataflow/APA/Analyses/Intra/ReachingDefinitions.cpp
@@ -1,5 +1,8 @@
 #include "Dataflow/APA/Analyses/Intra/ReachingDefinitions.h"
 
+#include "Dataflow/APA/Baseline/TranslAPA/AtomTranslator.h"
+#include "Dataflow/APA/Baseline/TranslAPA/Driver.h"
+
 #include "llvm/Analysis/MemoryLocation.h"
 #include "llvm/Analysis/MemorySSA.h"
 #include "llvm/IR/Instructions.h"
@@ -215,6 +218,72 @@ runIntraElimReachingDefinitions(llvm::Function *F, llvm::AAResults *AA,
   auto Status = Solver.solve();
   auto Out = Solver.getResults();
   Out.setSolveMetadata(Status, Solver.getDiagnostics());
+  return Out;
+}
+
+ReachingDefinitionsResult
+runIntraTranslApaReachingDefinitions(llvm::Function *F, llvm::AAResults *AA,
+                                     EliminationOptions Opts) {
+  if (F == nullptr || F->isDeclaration()) {
+    return ReachingDefinitionsResult{};
+  }
+
+  // Composition (EAN/Greedy ⊕ TranslAPA): those post-passes rewrite
+  // Results.ExprTo(N) to the optimized DAG in place. Enabling InterpMemo makes
+  // the solver's post-pass (and the base materialization) skip their generic
+  // eval, since we fill IN by folding the (now optimized) DAG ourselves. Without
+  // this the run would waste — and possibly time out on — a full generic
+  // interpretation of the graph we are about to fold instead. This is what turns
+  // "--ean --interp=translapa" into a genuine measurement of folding the
+  // EAN-reduced DAG. The EAN/Greedy normalization time is already accumulated in
+  // norm_time_us by the post-pass; we add the mechanical extraction below.
+  if (Opts.EnableEAN || Opts.EnableGreedy) {
+    Opts.InterpMemo = true;
+  }
+
+  ElimReachingDefinitionsProblem Problem(F, AA, nullptr);
+  IntraEliminationSolver<
+      LLVMAnalysisTypes<ReachingDefinitionsFact, ReachingDefinitionsDomain>>
+      Solver(Problem, Opts);
+  auto Status = Solver.solve();
+  auto Out = Solver.getResults();
+  auto Diag = Solver.getDiagnostics();
+
+  // The finite fact universe: every value the transfer can put in a fact set —
+  // function arguments (initial fact), store instructions, and non-void
+  // instructions (see applyTransfer above).
+  std::vector<const llvm::Value *> Universe;
+  for (auto &Arg : F->args()) {
+    Universe.push_back(&Arg);
+  }
+  for (auto &BB : *F) {
+    for (auto &I : BB) {
+      if (llvm::isa<llvm::StoreInst>(&I)) {
+        Universe.push_back(&I);
+      } else if (!I.getType()->isVoidTy()) {
+        Universe.push_back(&I);
+      }
+    }
+  }
+
+  translapa::GenKillAtomTranslator<llvm::Instruction *, ReachingDefinitionsFact>
+      Tr(std::move(Universe),
+         [&Problem](const llvm::Instruction *const &T,
+                    const ReachingDefinitionsFact &In) {
+           return Problem.applyTransfer(const_cast<llvm::Instruction *>(T), In);
+         },
+         /*Separable=*/true);
+
+  auto TT =
+      translapa::foldFillGenKillTimed<LLVMAnalysisTypes<
+          ReachingDefinitionsFact, ReachingDefinitionsDomain>>(Problem, Out, Tr);
+  // Extraction is the one-time IDA->APA translation cost (paper's construction);
+  // the closed-form fold is the per-query evaluation cost. Under EAN/Greedy the
+  // post-pass has already put its saturation time into norm_time_us, so we add
+  // (not overwrite) the extraction to report total construction = EAN + extract.
+  Diag.norm_time_us += TT.extract_us;
+  Diag.interp_time_us = TT.fold_us;
+  Out.setSolveMetadata(Status, Diag);
   return Out;
 }
 

--- a/lib/Dataflow/APA/CMakeLists.txt
+++ b/lib/Dataflow/APA/CMakeLists.txt
@@ -14,6 +14,7 @@ set(APA_SOURCES
   Analyses/Intra/Lockset.cpp
   Analyses/Intra/NonNull.cpp
   Analyses/Intra/Sign.cpp
+  Analyses/Intra/IntraAffineEqualities.cpp
   Analyses/Inter/Reachability.cpp
   Analyses/Inter/ConstantPropagation.cpp
   Analyses/Inter/Lockset.cpp

--- a/lib/Dataflow/APA/Domains/AffineRelationDomain.cpp
+++ b/lib/Dataflow/APA/Domains/AffineRelationDomain.cpp
@@ -164,9 +164,17 @@ bool componentIsBottom(const AffineRelationComponent &component) {
 AffineRelationComponent normalizeComponent(AffineRelationComponent component) {
   component.constraints =
       howellize(std::move(component.constraints), component.bitWidth);
-  const unsigned vars = numVarsFor(component.bitWidth);
   for (const Row &row : component.constraints) {
-    if (leadingIndex(row) == static_cast<int>(2 * vars) && row.back().isOne()) {
+    // A genuine contradiction is a row [0 … 0 | c] whose only nonzero entry is
+    // the augmented (constant) term — the LAST column. Using a fixed 2*vars
+    // index here mis-fires when normalizeComponent runs on the wider
+    // intermediate matrices built by composeComponent (3*vars+1) / joinComponent
+    // (4*vars+2), where column 2*vars is a middle variable, not the constant —
+    // turning a satisfiable inhomogeneous relation (e.g. v' = u + 1) into a
+    // false bottom. Anchor on the row's own last column instead.
+    if (!row.empty() &&
+        leadingIndex(row) == static_cast<int>(row.size()) - 1 &&
+        row.back().isOne()) {
       return bottomComponent(component.bitWidth);
     }
   }

--- a/tests/unit/Dataflow/APA/Baseline/TranslAPADriverTest.cpp
+++ b/tests/unit/Dataflow/APA/Baseline/TranslAPADriverTest.cpp
@@ -1,0 +1,194 @@
+/**
+ * @file TranslAPADriverTest.cpp
+ * @brief B2 solver-level differential: fold the SOLVER-produced path-expression
+ *        DAGs with the Gen/Kill semiring and require the result to match the
+ *        framework's own generic interpreter on every node — the paper's
+ *        "same set of dataflow facts" guarantee, checked over real elimination
+ *        output including Star (loops) and Union (branches).
+ */
+
+#include "Dataflow/APA/APA.h"
+#include "Dataflow/APA/Baseline/TranslAPA/AtomTranslator.h"
+#include "Dataflow/APA/Baseline/TranslAPA/Driver.h"
+
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// Gen/Kill "gen-on-visit" problem (same shape as EliminationTest's): visiting a
+// node gens its own id, kills nothing. Separable and distributive, so the
+// mechanical translator recovers ({id}, {}) per atom.
+struct TestDomain {
+  using n_t = int;
+  using fact_t = std::set<int>;
+  using transfer_t = int;
+  using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+};
+
+class GenProblem final : public elimination::IntraEliminationProblem<TestDomain> {
+public:
+  GenProblem(int Entry, std::unordered_map<int, std::vector<int>> Succs)
+      : Entry(Entry), Succs(std::move(Succs)) {}
+
+  std::vector<int> nodes() const override {
+    std::vector<int> Ns;
+    Ns.reserve(Succs.size());
+    for (const auto &It : Succs) {
+      Ns.push_back(It.first);
+    }
+    return Ns;
+  }
+  int entry() const override { return Entry; }
+  std::vector<int> succs(int Node) const override {
+    auto It = Succs.find(Node);
+    return It == Succs.end() ? std::vector<int>{} : It->second;
+  }
+  int edgeTransfer(int, int Dst) const override { return Dst; }
+  fact_t applyTransfer(const int &T, const fact_t &In) const override {
+    fact_t Out = In;
+    Out.insert(T);
+    return Out;
+  }
+  fact_t join(const fact_t &A, const fact_t &B) const override {
+    fact_t Out = A;
+    Out.insert(B.begin(), B.end());
+    return Out;
+  }
+  bool equal(const fact_t &A, const fact_t &B) const override {
+    return A == B;
+  }
+  fact_t bottom() const override { return {}; }
+  fact_t initialFact() const override { return {}; }
+  std::size_t maxStarIterations() const override { return 1000; }
+
+private:
+  int Entry;
+  std::unordered_map<int, std::vector<int>> Succs;
+};
+
+// Run the solver (generic IN), then fold the produced DAGs with the Gen/Kill
+// semiring and assert node-by-node agreement.
+void expectTranslApaMatchesGeneric(
+    int Entry, std::unordered_map<int, std::vector<int>> Succs) {
+  GenProblem Problem(Entry, Succs);
+  elimination::IntraEliminationSolver<TestDomain> Solver(Problem);
+  Solver.solve();
+  auto Generic = Solver.getResults(); // snapshot generic IN + ExprTo
+
+  // Universe = all node ids (every gen'd fact is a node id).
+  std::vector<int> Universe;
+  for (const auto &It : Succs) {
+    Universe.push_back(It.first);
+  }
+  elimination::translapa::GenKillAtomTranslator<int, std::set<int>> Tr(
+      Universe,
+      [&Problem](const int &T, const std::set<int> &In) {
+        return Problem.applyTransfer(T, In);
+      });
+
+  auto TranslApa = Generic; // copy: keeps ExprTo, we overwrite IN
+  elimination::translapa::foldFillGenKill<TestDomain>(Problem, TranslApa, Tr);
+
+  for (const int N : Universe) {
+    const auto *G = Generic.tryIN(N);
+    const auto *T = TranslApa.tryIN(N);
+    ASSERT_EQ(G != nullptr, T != nullptr) << "node " << N;
+    if (G != nullptr) {
+      EXPECT_EQ(*G, *T) << "mismatch at node " << N;
+    }
+  }
+}
+
+TEST(TranslAPADriver, LoopMatchesGeneric) {
+  // 0 -> 1 -> 2 -> 3 with back edge 2 -> 1 (Star over {1,2}).
+  expectTranslApaMatchesGeneric(
+      0, {{0, {1}}, {1, {2}}, {2, {1, 3}}, {3, {}}});
+}
+
+TEST(TranslAPADriver, BranchMatchesGeneric) {
+  // Diamond 0 -> {1,2} -> 3 (Union).
+  expectTranslApaMatchesGeneric(0, {{0, {1, 2}}, {1, {3}}, {2, {3}}, {3, {}}});
+}
+
+TEST(TranslAPADriver, SelfLoopMatchesGeneric) {
+  expectTranslApaMatchesGeneric(0, {{0, {0}}});
+}
+
+TEST(TranslAPADriver, NestedLoopMatchesGeneric) {
+  // Outer loop 1..4 with inner loop 2..3.
+  expectTranslApaMatchesGeneric(0, {{0, {1}},
+                                    {1, {2}},
+                                    {2, {3}},
+                                    {3, {2, 4}},
+                                    {4, {1, 5}},
+                                    {5, {}}});
+}
+
+// Composition (EAN ⊕ TranslAPA): run the solver with EAN enabled so the
+// front-end rewrites Results.ExprTo(N) to the equality-saturated (reduced) DAG,
+// then fold THAT DAG with the closed-form Gen/Kill semiring. The result must
+// still match the generic interpreter on the raw DAG — this is the correctness
+// half of the "two orthogonal levers compose" experiment: EAN shrinks the graph
+// (safe-minimal laws preserve semantics) and TranslAPA folds it in closed form,
+// so folding the smaller graph yields the same facts.
+void expectComposedMatchesGeneric(
+    int Entry, std::unordered_map<int, std::vector<int>> Succs) {
+  GenProblem Problem(Entry, Succs);
+
+  // Reference: generic interpreter on the raw DAG (no EAN).
+  elimination::IntraEliminationSolver<TestDomain> Generic(Problem);
+  Generic.solve();
+  auto GenericRes = Generic.getResults();
+
+  // Composed: EAN rewrites ExprTo to the reduced DAG; InterpMemo makes the
+  // post-pass skip its (discarded) generic eval. We then fold the reduced DAG.
+  elimination::EliminationOptions Opts;
+  Opts.EnableEAN = true;      // default EANLaws = safe-minimal (universally sound)
+  Opts.InterpMemo = true;     // fill IN by folding, not by the generic eval
+  elimination::IntraEliminationSolver<TestDomain> EanSolver(Problem, Opts);
+  EanSolver.solve();
+  auto Composed = EanSolver.getResults();
+
+  std::vector<int> Universe;
+  for (const auto &It : Succs) {
+    Universe.push_back(It.first);
+  }
+  elimination::translapa::GenKillAtomTranslator<int, std::set<int>> Tr(
+      Universe,
+      [&Problem](const int &T, const std::set<int> &In) {
+        return Problem.applyTransfer(T, In);
+      });
+  elimination::translapa::foldFillGenKill<TestDomain>(Problem, Composed, Tr);
+
+  for (const int N : Universe) {
+    const auto *G = GenericRes.tryIN(N);
+    const auto *C = Composed.tryIN(N);
+    ASSERT_EQ(G != nullptr, C != nullptr) << "node " << N;
+    if (G != nullptr) {
+      EXPECT_EQ(*G, *C) << "composed mismatch at node " << N;
+    }
+  }
+}
+
+TEST(TranslAPADriver, ComposedLoopMatchesGeneric) {
+  expectComposedMatchesGeneric(0, {{0, {1}}, {1, {2}}, {2, {1, 3}}, {3, {}}});
+}
+
+TEST(TranslAPADriver, ComposedBranchMatchesGeneric) {
+  expectComposedMatchesGeneric(0, {{0, {1, 2}}, {1, {3}}, {2, {3}}, {3, {}}});
+}
+
+TEST(TranslAPADriver, ComposedNestedLoopMatchesGeneric) {
+  expectComposedMatchesGeneric(0, {{0, {1}},
+                                   {1, {2}},
+                                   {2, {3}},
+                                   {3, {2, 4}},
+                                   {4, {1, 5}},
+                                   {5, {}}});
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/Baseline/TranslAPAGenKillTest.cpp
+++ b/tests/unit/Dataflow/APA/Baseline/TranslAPAGenKillTest.cpp
@@ -1,0 +1,203 @@
+/**
+ * @file TranslAPAGenKillTest.cpp
+ * @brief B1 unit tests for the TranslAPA baseline Gen/Kill semiring, mechanical
+ *        atom translator, and memoized DAG fold interpreter.
+ *
+ * These tests are meaning-agnostic (paper §3): the translator recovers (Gen,
+ * Kill) purely by probing a plain applyTransfer callable over a finite fact
+ * universe. The end-to-end case reproduces the reaching-definitions example of
+ * the paper's Fig. 1, whose path expression is 1 . (4 . 5 + 7)* . 10 and whose
+ * reaching definitions at the exit are {1, 4, 10}.
+ */
+
+#include "Dataflow/APA/Baseline/TranslAPA/AtomTranslator.h"
+#include "Dataflow/APA/Baseline/TranslAPA/FoldInterpreter.h"
+#include "Dataflow/APA/Baseline/TranslAPA/GenKillSemiring.h"
+#include "Dataflow/APA/Core/PathExpr.h"
+
+#include <functional>
+#include <set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using elimination::PathExprFactory;
+using elimination::translapa::GenKillAtomTranslator;
+using elimination::translapa::GenKillFact;
+using elimination::translapa::GenKillSemiring;
+using elimination::translapa::makeFoldInterpreter;
+
+namespace {
+
+using Fact = std::set<int>;
+
+// Standard separable reaching-definitions transfer: an atom is a definition id;
+// applying it kills all definitions of the same variable then gens itself.
+struct RDModel {
+  // variable owning each definition id (paper Fig. 1: x -> {1,4}, y -> {5,7,10})
+  std::function<char(int)> var;
+
+  Fact apply(int Def, const Fact &In) const {
+    Fact Out;
+    for (int D : In) {
+      if (var(D) != var(Def)) {
+        Out.insert(D);
+      }
+    }
+    Out.insert(Def);
+    return Out;
+  }
+};
+
+RDModel figure1Model() {
+  return RDModel{[](int D) -> char {
+    return (D == 1 || D == 4) ? 'x' : 'y'; // 5,7,10 -> y
+  }};
+}
+
+GenKillAtomTranslator<int, Fact> figure1Translator(const RDModel &M) {
+  std::vector<int> Universe = {1, 4, 5, 7, 10};
+  return GenKillAtomTranslator<int, Fact>(
+      Universe, [M](const int &T, const Fact &In) { return M.apply(T, In); });
+}
+
+// Reference generic interpreter that mirrors SolverContext::eval exactly, used
+// as the differential oracle the paper guarantees the semiring agrees with.
+struct GenericEval {
+  const RDModel &M;
+  using Factory = PathExprFactory<int>;
+  using Ref = typename Factory::Ref;
+  using Kind = typename Factory::Kind;
+
+  Fact meet(const Fact &A, const Fact &B) const {
+    Fact Out = A;
+    Out.insert(B.begin(), B.end());
+    return Out; // may-union confluence
+  }
+
+  Fact eval(const Ref &E, const Fact &In) const {
+    switch (E->K) {
+    case Kind::Zero:
+      return Fact{};
+    case Kind::One:
+      return In;
+    case Kind::Atom:
+      return M.apply(*E->Transfer, In);
+    case Kind::Union:
+      return meet(eval(E->L, In), eval(E->R, In));
+    case Kind::Concat:
+      return eval(E->R, eval(E->L, In)); // L first
+    case Kind::Star: {
+      Fact Cur = In;
+      for (int I = 0; I < 100000; ++I) {
+        Fact Next = meet(In, eval(E->L, Cur));
+        if (Next == Cur) {
+          return Cur;
+        }
+        Cur = std::move(Next);
+      }
+      return Cur;
+    }
+    }
+    return Fact{};
+  }
+};
+
+// ---- semiring algebra --------------------------------------------------------
+
+// bit helpers for compact element construction in algebra tests.
+llvm::BitVector bits(unsigned N, std::initializer_list<unsigned> Set) {
+  llvm::BitVector B(N, false);
+  for (unsigned I : Set) {
+    B.set(I);
+  }
+  return B;
+}
+
+TEST(TranslAPAGenKill, UnitsAndApply) {
+  GenKillSemiring S(3);
+  // one() is identity: apply(one, x) == x.
+  auto X = bits(3, {0, 2});
+  EXPECT_EQ(S.apply(S.one(), X), X);
+  // zero() absorbs in join: join(zero, e) == e.
+  GenKillFact E{bits(3, {1}), bits(3, {0})};
+  EXPECT_EQ(S.join(S.zero(), E), E);
+  EXPECT_EQ(S.join(E, S.zero()), E);
+}
+
+TEST(TranslAPAGenKill, SeqOrientationLFirst) {
+  // L = "gen 0, kill 1"; R = "gen 1, kill 0". Applying L then R to {} must gen
+  // both bits but R's kill of 0 removes L's gen-0 that is not re-gen'd by R.
+  GenKillSemiring S(2);
+  GenKillFact L{bits(2, {0}), bits(2, {1})};
+  GenKillFact R{bits(2, {1}), bits(2, {0})};
+  auto Seq = S.seq(L, R); // R . L
+  // Gen = R.Gen | (L.Gen \ R.Kill) = {1} | ({0}\{0}) = {1}
+  EXPECT_EQ(Seq.Gen, bits(2, {1}));
+  // Kill = L.Kill | R.Kill = {1} | {0} = {0,1}
+  EXPECT_EQ(Seq.Kill, bits(2, {0, 1}));
+  // apply(seq, {}) == R(L({})) == {1}
+  EXPECT_EQ(S.apply(Seq, bits(2, {})), bits(2, {1}));
+}
+
+TEST(TranslAPAGenKill, JoinAndStar) {
+  GenKillSemiring S(3);
+  GenKillFact A{bits(3, {0}), bits(3, {0, 1})};
+  GenKillFact B{bits(3, {2}), bits(3, {1, 2})};
+  auto J = S.join(A, B);
+  EXPECT_EQ(J.Gen, bits(3, {0, 2}));  // union
+  EXPECT_EQ(J.Kill, bits(3, {1}));    // intersection
+  auto St = S.star(A);
+  EXPECT_EQ(St.Gen, A.Gen);
+  EXPECT_EQ(St.Kill, bits(3, {})); // Kill* is empty
+}
+
+// ---- mechanical extraction ---------------------------------------------------
+
+TEST(TranslAPAGenKill, MechanicalExtractionMatchesPaper) {
+  auto M = figure1Model();
+  auto T = figure1Translator(M);
+  // D[1] = ({1}, {4}) in paper's Fig.1 walkthrough.
+  auto G1 = T.translate(1);
+  EXPECT_EQ(T.fromBits(G1.Gen), (Fact{1}));
+  EXPECT_EQ(T.fromBits(G1.Kill), (Fact{4}));
+  // D[5] = ({5}, {7,10}).
+  auto G5 = T.translate(5);
+  EXPECT_EQ(T.fromBits(G5.Gen), (Fact{5}));
+  EXPECT_EQ(T.fromBits(G5.Kill), (Fact{7, 10}));
+}
+
+// ---- end-to-end fold over Fig. 1 --------------------------------------------
+
+TEST(TranslAPAGenKill, Figure1ReachingDefinitions) {
+  auto M = figure1Model();
+  auto T = figure1Translator(M);
+  GenKillSemiring S(T.universeSize());
+
+  // Build p = 1 . (4 . 5 + 7)* . 10 as a hash-consed DAG.
+  PathExprFactory<int> F;
+  auto A1 = F.atom(1), A4 = F.atom(4), A5 = F.atom(5), A7 = F.atom(7),
+       A10 = F.atom(10);
+  auto Seq45 = F.concat(A4, A5);
+  auto Branch = F.unite(Seq45, A7);
+  auto Loop = F.star(Branch);
+  auto Root = F.concat(A1, F.concat(Loop, A10));
+
+  auto Interp = makeFoldInterpreter<int>(
+      S, [&T](const int &Tr) { return T.translate(Tr); });
+  GenKillFact Summary = Interp.fold(Root);
+
+  // Applied to the empty entry fact, the reaching definitions at the exit are
+  // exactly {1, 4, 10} (paper Fig. 1 / §2.3).
+  llvm::BitVector Init(T.universeSize(), false);
+  Fact Got = T.fromBits(S.apply(Summary, Init));
+  EXPECT_EQ(Got, (Fact{1, 4, 10}));
+
+  // Differential oracle: the closed-form semiring must agree with the generic
+  // fixpoint-iterating interpreter on the same path expression.
+  GenericEval Ref{M};
+  Fact Reference = Ref.eval(Root, Fact{});
+  EXPECT_EQ(Got, Reference);
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/CMakeLists.txt
+++ b/tests/unit/Dataflow/APA/CMakeLists.txt
@@ -13,5 +13,24 @@ add_lotus_test_suite(apa_tests
     InterAffineCastAndArithmeticTest.cpp
     InterAffineBitwiseCongruenceTest.cpp
     InterSummaryTransferTest.cpp
+    CallGraphSCCTest.cpp
+    ModularInterSummarySolverTest.cpp
+    ModularInterSummaryDriverTest.cpp
     PathSummaryEquationSolverTest.cpp
-  LINK_LIBS APADataFlow)
+    OrderTest.cpp
+    EAN/RoundtripTest.cpp
+    EAN/FactorizeTest.cpp
+    EAN/SaturateTest.cpp
+    EAN/BatchExtractTest.cpp
+    EAN/StarTest.cpp
+    EAN/SolverWiringTest.cpp
+    EAN/EvalRq1Test.cpp
+    EAN/EvalRq3Test.cpp
+    EAN/GreedyTest.cpp
+    EAN/InterWiringTest.cpp
+    EAN/AffineEanTest.cpp
+    EAN/ExpandTest.cpp
+    EAN/EvalExportTest.cpp
+    Baseline/TranslAPAGenKillTest.cpp
+    Baseline/TranslAPADriverTest.cpp
+  LINK_LIBS APADataFlow LotusEGraph)

--- a/tests/unit/Dataflow/APA/CallGraphSCCTest.cpp
+++ b/tests/unit/Dataflow/APA/CallGraphSCCTest.cpp
@@ -1,0 +1,156 @@
+#include "Dataflow/APA/Solver/CallGraphSCC.h"
+
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// Minimal configurable interprocedural-CFG stub for call-graph tests.
+// Procedures and instructions are ints. A procedure is "opaque" (external) iff
+// it has no start or exit points.
+struct FakeCG {
+  std::unordered_map<int, std::vector<int>> Insts;    // proc -> instructions
+  std::unordered_map<int, std::vector<int>> Callees;  // call inst -> callees
+  std::unordered_map<int, std::vector<int>> Starts;   // proc -> start points
+  std::unordered_map<int, std::vector<int>> Exits;    // proc -> exit points
+
+  std::vector<int> getAllInstructionsOf(int F) const {
+    auto It = Insts.find(F);
+    return It == Insts.end() ? std::vector<int>{} : It->second;
+  }
+  bool isCallSite(int Inst) const { return Callees.count(Inst) != 0; }
+  std::vector<int> getCalleesOfCallAt(int Inst) const {
+    auto It = Callees.find(Inst);
+    return It == Callees.end() ? std::vector<int>{} : It->second;
+  }
+  std::vector<int> getStartPointsOf(int F) const {
+    auto It = Starts.find(F);
+    return It == Starts.end() ? std::vector<int>{} : It->second;
+  }
+  std::vector<int> getExitPointsOf(int F) const {
+    auto It = Exits.find(F);
+    return It == Exits.end() ? std::vector<int>{} : It->second;
+  }
+
+  // Helper: declare a normal (non-opaque) procedure with one call-site inst
+  // pointing at the given callees.
+  void addProc(int F, std::vector<int> CalleeProcs) {
+    Starts[F] = {F * 100};      // arbitrary distinct entry
+    Exits[F] = {F * 100 + 1};   // arbitrary distinct exit
+    const int CallInst = F * 100 + 2;
+    Insts[F] = {F * 100, CallInst, F * 100 + 1};
+    if (!CalleeProcs.empty()) {
+      Callees[CallInst] = std::move(CalleeProcs);
+    }
+  }
+};
+
+using Builder = elimination::CallGraphSCCBuilder<int, int, FakeCG>;
+using Result = elimination::CallGraphSCCResult<int>;
+
+// Index of the component containing proc F (or -1).
+int compOf(const Result &R, int F) {
+  for (std::size_t I = 0; I < R.order.size(); ++I) {
+    for (int P : R.order[I].procs) {
+      if (P == F) {
+        return static_cast<int>(I);
+      }
+    }
+  }
+  return -1;
+}
+
+TEST(CallGraphSCC, LinearChainReverseTopo) {
+  FakeCG CG;
+  CG.addProc(1, {2}); // A -> B
+  CG.addProc(2, {3}); // B -> C
+  CG.addProc(3, {});  // C -> (leaf)
+
+  Builder B(CG);
+  auto R = B.build({1});
+
+  ASSERT_EQ(R.order.size(), 3u);
+  // Callees before callers: C < B < A.
+  EXPECT_LT(compOf(R, 3), compOf(R, 2));
+  EXPECT_LT(compOf(R, 2), compOf(R, 1));
+  for (const auto &C : R.order) {
+    EXPECT_FALSE(C.recursive);
+    EXPECT_EQ(C.procs.size(), 1u);
+  }
+}
+
+TEST(CallGraphSCC, DirectSelfRecursion) {
+  FakeCG CG;
+  CG.addProc(1, {1}); // A -> A
+
+  Builder B(CG);
+  auto R = B.build({1});
+
+  ASSERT_EQ(R.order.size(), 1u);
+  EXPECT_EQ(R.order[0].procs.size(), 1u);
+  EXPECT_TRUE(R.order[0].recursive);
+}
+
+TEST(CallGraphSCC, MutualRecursionFormsOneComponent) {
+  FakeCG CG;
+  CG.addProc(1, {2}); // A -> B
+  CG.addProc(2, {1}); // B -> A
+
+  Builder B(CG);
+  auto R = B.build({1});
+
+  ASSERT_EQ(R.order.size(), 1u);
+  EXPECT_EQ(R.order[0].procs.size(), 2u);
+  EXPECT_TRUE(R.order[0].recursive);
+  EXPECT_EQ(compOf(R, 1), compOf(R, 2));
+}
+
+TEST(CallGraphSCC, DiamondOrdersLeafFirstRootLast) {
+  FakeCG CG;
+  // A -> B, A -> C ; B -> D ; C -> D.
+  CG.Starts[1] = {100};
+  CG.Exits[1] = {101};
+  CG.Insts[1] = {100, 102, 103, 101};
+  CG.Callees[102] = {2};
+  CG.Callees[103] = {3};
+  CG.addProc(2, {4}); // B -> D
+  CG.addProc(3, {4}); // C -> D
+  CG.addProc(4, {});  // D leaf
+
+  Builder B(CG);
+  auto R = B.build({1});
+
+  ASSERT_EQ(R.order.size(), 4u);
+  // D before B and C; B and C before A.
+  EXPECT_LT(compOf(R, 4), compOf(R, 2));
+  EXPECT_LT(compOf(R, 4), compOf(R, 3));
+  EXPECT_LT(compOf(R, 2), compOf(R, 1));
+  EXPECT_LT(compOf(R, 3), compOf(R, 1));
+}
+
+TEST(CallGraphSCC, ExternalCalleeExcluded) {
+  FakeCG CG;
+  CG.addProc(1, {9}); // A -> ext(9)
+  // Proc 9 has no start/exit points -> opaque, not a node.
+
+  Builder B(CG);
+  auto R = B.build({1});
+
+  ASSERT_EQ(R.order.size(), 1u);
+  EXPECT_EQ(R.order[0].procs.size(), 1u);
+  EXPECT_EQ(R.order[0].procs[0], 1);
+  EXPECT_EQ(compOf(R, 9), -1); // external callee never interned
+}
+
+TEST(CallGraphSCC, OpaqueEntryYieldsEmptyGraph) {
+  FakeCG CG; // proc 1 declared with no start/exit -> opaque
+
+  Builder B(CG);
+  auto R = B.build({1});
+
+  EXPECT_TRUE(R.order.empty());
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/EAN/AffineEanTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/AffineEanTest.cpp
@@ -1,0 +1,267 @@
+// Intraprocedural affine-equalities EAN client tests.
+//
+// The affine-relation framework is DISTRIBUTIVE (relational composition
+// distributes over the affine-hull join), so — unlike reachability/liveness —
+// the full Kleene EAN law profile should be sound here: EAN(safe), EAN(kleene),
+// and Greedy must all reproduce the Default facts exactly. This is the paper's
+// positive R1 (law-gated admissibility) case. We also pin the underlying
+// distributivity equation directly.
+
+#include "Dataflow/APA/Analyses/Intra/IntraAffineEqualities.h"
+#include "Dataflow/APA/Domains/AffineRelationDomain.h"
+
+#include "TestUtils/LLVMHelpers.h"
+
+#include <map>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/InstIterator.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+
+namespace {
+
+using elimination::AffineFact;
+using elimination::AffineResult;
+using D = elimination::AffineRelationDomain;
+
+// Build + install a vocabulary of tracked integer scalars of the single
+// dominant bit-width (mirrors the analysis's own rule). Kept alive by the
+// caller so the static domain configuration stays valid while we inspect facts.
+elimination::AffineRelationVocabulary buildVocab(llvm::Function &F) {
+  auto widthOf = [](const llvm::Value *V) -> unsigned {
+    auto *IT = llvm::dyn_cast<llvm::IntegerType>(V->getType());
+    return (IT && IT->getBitWidth() <= 64) ? IT->getBitWidth() : 0;
+  };
+  std::map<unsigned, unsigned> Counts;
+  for (auto &Arg : F.args())
+    if (unsigned W = widthOf(&Arg))
+      ++Counts[W];
+  for (auto &I : llvm::instructions(F))
+    if (unsigned W = widthOf(&I))
+      ++Counts[W];
+  unsigned Dom = 0, Best = 0;
+  for (auto &[W, C] : Counts)
+    if (C > Best || (C == Best && W > Dom)) {
+      Dom = W;
+      Best = C;
+    }
+
+  elimination::AffineRelationVocabulary Vocab;
+  auto Add = [&](const llvm::Value *V) {
+    if (widthOf(V) != Dom || Dom == 0 || Vocab.indices.count(V))
+      return;
+    const unsigned Idx = static_cast<unsigned>(Vocab.values.size());
+    Vocab.indices.emplace(V, Idx);
+    Vocab.actualBitWidths.emplace(V, Dom);
+    Vocab.values.push_back(V);
+  };
+  for (auto &Arg : F.args())
+    Add(&Arg);
+  for (auto &I : llvm::instructions(F))
+    Add(&I);
+  return Vocab;
+}
+
+elimination::EliminationOptions defaultOpts() { return {}; }
+elimination::EliminationOptions eanSafeOpts() {
+  elimination::EliminationOptions O;
+  O.EnableEAN = true;
+  O.EANLaws = elimination::ean::LawProfile::safeMinimal();
+  return O;
+}
+elimination::EliminationOptions eanKleeneOpts() {
+  elimination::EliminationOptions O;
+  O.EnableEAN = true;
+  O.EANLaws = elimination::ean::LawProfile::kleeneAlgebra();
+  return O;
+}
+elimination::EliminationOptions greedyOpts() {
+  elimination::EliminationOptions O;
+  O.EnableGreedy = true;
+  return O;
+}
+// A function with affine assignments, a merge, and a loop (Star).
+const char *kLoopFn = R"LL(
+define i32 @f(i32 %n) {
+entry:
+  %a = add i32 %n, 1
+  br label %loop
+loop:
+  %i = phi i32 [ %a, %entry ], [ %i2, %loop ]
+  %i2 = add i32 %i, 2
+  %c = icmp slt i32 %i2, 100
+  br i1 %c, label %loop, label %exit
+exit:
+  %r = add i32 %i2, 5
+  ret i32 %r
+}
+)LL";
+
+// Assert that a config reproduces the Default facts at every instruction.
+void expectSameFacts(llvm::Function &F, const elimination::EliminationOptions &O,
+                     const char *Label) {
+  const AffineResult Base = elimination::runIntraElimAffine(&F, defaultOpts());
+  const AffineResult Got = elimination::runIntraElimAffine(&F, O);
+  // Re-install the vocabulary (each run reconfigured with its own local copy).
+  auto Vocab = buildVocab(F);
+  D::configure(&Vocab);
+  unsigned Idx = 0;
+  for (auto &I : llvm::instructions(F)) {
+    const auto *B = Base.tryIN(&I);
+    const auto *G = Got.tryIN(&I);
+    ASSERT_EQ(B != nullptr, G != nullptr)
+        << Label << " presence @inst#" << Idx;
+    if (B != nullptr && G != nullptr) {
+      EXPECT_TRUE(D::equal(*B, *G))
+          << Label << " fact differs @inst#" << Idx;
+    }
+    ++Idx;
+  }
+}
+
+TEST(AffineEan, TransferDistributesOverJoin) {
+  llvm::LLVMContext Ctx;
+  auto M = lotus::unittest::parseModuleChecked(
+      Ctx, "define void @g(i32 %x, i32 %y) {\n  ret void\n}\n");
+  auto *G = M->getFunction("g");
+  ASSERT_NE(G, nullptr);
+  auto Vocab = buildVocab(*G);
+  D::configure(&Vocab);
+
+  auto *X = G->getArg(0);
+  auto *Y = G->getArg(1);
+  // a: x' = 5 ; b: identity ; T: y' = x
+  const AffineFact A = D::makeAffineAssignment(X, 5, {});
+  const AffineFact B = D::identity();
+  const AffineFact T = D::makeAffineAssignment(Y, 0, {{X, 1}});
+
+  // Sanity: the domain builders must produce informative (non-bottom,
+  // non-identity) relations, else the equalities below hold vacuously.
+  ASSERT_FALSE(D::isBottom(A)) << "makeAffineAssignment produced bottom";
+  ASSERT_FALSE(D::equal(A, D::identity())) << "x'=5 collapsed to identity";
+  ASSERT_FALSE(D::isBottom(D::extend(T, B)))
+      << "extend(assignment, identity) produced bottom";
+
+  const AffineFact Lhs = D::extend(T, D::combine(A, B));
+  const AffineFact Rhs = D::combine(D::extend(T, A), D::extend(T, B));
+  EXPECT_TRUE(D::equal(Lhs, Rhs))
+      << "affine transfer must distribute over the join (kleene soundness)";
+}
+
+TEST(AffineEan, DomainComposeThreeVars) {
+  llvm::LLVMContext Ctx;
+  auto M = lotus::unittest::parseModuleChecked(
+      Ctx, "define void @g(i32 %x, i32 %y, i32 %z) {\n  ret void\n}\n");
+  auto *G = M->getFunction("g");
+  ASSERT_NE(G, nullptr);
+  auto Vocab = buildVocab(*G); // {x,y,z}, all i32
+  D::configure(&Vocab);
+  auto *X = G->getArg(0);
+  auto *Y = G->getArg(1);
+  std::string Bad;
+  for (int64_t C : {0, 1, 2, 3, 4, 5, 6, 8, 16}) {
+    const AffineFact T = D::makeAffineAssignment(Y, C, {{X, 1}}); // y' = x + C
+    if (D::isBottom(D::extend(T, D::identity())))
+      Bad += " " + std::to_string(C);
+  }
+  EXPECT_TRUE(Bad.empty()) << "extend(y'=x+C, identity) bottom for C in:" << Bad;
+}
+
+TEST(AffineEan, ComputesNonTrivialAffineFacts) {
+  llvm::LLVMContext Ctx;
+  auto M = lotus::unittest::parseModuleChecked(
+      Ctx,
+      "define i32 @s(i32 %n) {\n"
+      "  %a = add i32 %n, 1\n"
+      "  %b = add i32 %a, 2\n"
+      "  ret i32 %b\n"
+      "}\n");
+  auto *F = M->getFunction("s");
+  ASSERT_NE(F, nullptr);
+
+  const AffineResult Res = elimination::runIntraElimAffine(F, {});
+  auto Vocab = buildVocab(*F);
+  D::configure(&Vocab);
+  unsigned Total = 0, NonNull = 0, Bottom = 0, Informative = 0;
+  for (auto &I : llvm::instructions(*F)) {
+    ++Total;
+    const auto *Fact = Res.tryIN(&I);
+    if (Fact == nullptr)
+      continue;
+    ++NonNull;
+    if (D::isBottom(*Fact)) {
+      ++Bottom;
+    } else if (!D::equal(*Fact, D::identity())) {
+      ++Informative;
+    }
+  }
+  // Facts must be populated (preservation tests would be vacuous otherwise),
+  // reachable code must not be bottom, and the analysis must capture at least
+  // one non-identity affine relation.
+  EXPECT_EQ(NonNull, Total) << "some IN facts missing";
+  EXPECT_EQ(Bottom, 0u) << "reachable code should not be bottom";
+  EXPECT_GT(Informative, 0u)
+      << "no informative affine fact (Total=" << Total
+      << " NonNull=" << NonNull << " Bottom=" << Bottom << ")";
+}
+
+TEST(AffineEan, EanSafePreservesFacts) {
+  llvm::LLVMContext Ctx;
+  auto M = lotus::unittest::parseModuleChecked(Ctx, kLoopFn);
+  auto *F = M->getFunction("f");
+  ASSERT_NE(F, nullptr);
+  expectSameFacts(*F, eanSafeOpts(), "EAN(safe)");
+}
+
+// The centerpiece: full Kleene is sound for the distributive affine client.
+TEST(AffineEan, EanKleenePreservesFacts) {
+  llvm::LLVMContext Ctx;
+  auto M = lotus::unittest::parseModuleChecked(Ctx, kLoopFn);
+  auto *F = M->getFunction("f");
+  ASSERT_NE(F, nullptr);
+  expectSameFacts(*F, eanKleeneOpts(), "EAN(kleene)");
+}
+
+TEST(AffineEan, GreedyPreservesFacts) {
+  llvm::LLVMContext Ctx;
+  auto M = lotus::unittest::parseModuleChecked(Ctx, kLoopFn);
+  auto *F = M->getFunction("f");
+  ASSERT_NE(F, nullptr);
+  expectSameFacts(*F, greedyOpts(), "Greedy");
+}
+
+// The memoizing transformer interpreter must produce IDENTICAL facts to the
+// tree-walking interpreter (semantic equivalence), both with and without EAN.
+TEST(AffineEan, MemoInterpreterMatchesTreeInterpreter) {
+  llvm::LLVMContext Ctx;
+  auto M = lotus::unittest::parseModuleChecked(Ctx, kLoopFn);
+  auto *F = M->getFunction("f");
+  ASSERT_NE(F, nullptr);
+
+  auto memo = [](elimination::EliminationOptions O) {
+    O.InterpMemo = true;
+    return O;
+  };
+  // Tree (baseline) vs memo, under Default and under EAN(kleene).
+  for (const auto &Base : {defaultOpts(), eanKleeneOpts()}) {
+    const AffineResult Tree = elimination::runIntraElimAffine(F, Base);
+    const AffineResult Memo = elimination::runIntraElimAffine(F, memo(Base));
+    auto Vocab = buildVocab(*F);
+    D::configure(&Vocab);
+    unsigned Idx = 0;
+    for (auto &I : llvm::instructions(*F)) {
+      const auto *T = Tree.tryIN(&I);
+      const auto *Mm = Memo.tryIN(&I);
+      ASSERT_EQ(T != nullptr, Mm != nullptr) << "presence @inst#" << Idx;
+      if (T != nullptr && Mm != nullptr) {
+        EXPECT_TRUE(D::equal(*T, *Mm)) << "memo != tree @inst#" << Idx;
+      }
+      ++Idx;
+    }
+  }
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/EAN/BatchExtractTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/BatchExtractTest.cpp
@@ -1,0 +1,287 @@
+// EAN M4 tests: reuse-aware batch extraction (Algorithm 2), the Eq. 5 objective,
+// cycle-safe extraction, and the switchable plateau mode.
+
+#include "Dataflow/APA/EAN/BatchExtract.h"
+#include "Dataflow/APA/EAN/Canonical.h"
+#include "Dataflow/APA/EAN/EAN.h"
+#include "Dataflow/APA/EAN/Export.h"
+#include "Dataflow/APA/EAN/Factorize.h"
+#include "Dataflow/APA/EAN/Import.h"
+
+#include "BoolKleene.h"
+
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace lotus_test_ean;
+namespace ean = elimination::ean;
+using ean::CostModel;
+using ean::ExtractOptions;
+using ean::Graph;
+using ean::Id;
+using ean::LawProfile;
+using ean::PathLang;
+using Factory = elimination::PathExprFactory<int>;
+using Ref = Factory::Ref;
+
+void collectUnique(const Ref &e, std::unordered_set<const void *> &seen) {
+  if (!e || !seen.insert(e.get()).second) return;
+  if (e->L) collectUnique(e->L, seen);
+  if (e->R) collectUnique(e->R, seen);
+}
+std::size_t countUnique(const std::vector<Ref> &roots) {
+  std::unordered_set<const void *> seen;
+  for (const auto &r : roots) collectUnique(r, seen);
+  return seen.size();
+}
+
+Ref seq3(Factory &F, Ref x, Ref y, Ref z) {
+  return F.concat(F.concat(x, y), z);
+}
+
+std::uint64_t g_seed = 0x5A1AD;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+Ref randExpr(Factory &F, int depth) {
+  if (depth <= 0 || (rnd() % 3 == 0)) return F.atom(static_cast<int>(rnd() % 5));
+  switch (rnd() % 4) {
+  case 0: return F.unite(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 1: return F.concat(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 2: return F.star(randExpr(F, depth - 1));
+  default: return F.atom(static_cast<int>(rnd() % 5));
+  }
+}
+
+} // namespace
+
+// dagCost computes Eq. 5 correctly on tiny known graphs.
+TEST(EanBatchExtract, DagCostFormula) {
+  ExtractOptions o0;
+  o0.reuseIters = 0;
+
+  { // single atom: alpha*1 + wAtom*1 = 2
+    Factory F;
+    auto imp = ean::importCanonical<int>({F.atom(0)});
+    double c = ean::reuseAwareExtract(imp.g, imp.roots, CostModel::uniform(), o0).dagCost;
+    EXPECT_DOUBLE_EQ(c, 2.0);
+  }
+  { // a·b: N_unique=3, opTerm=wAtom+wAtom+wSeq=3 -> 1*3+3 = 6
+    Factory F;
+    auto imp = ean::importCanonical<int>({F.concat(F.atom(0), F.atom(1))});
+    double c = ean::reuseAwareExtract(imp.g, imp.roots, CostModel::uniform(), o0).dagCost;
+    EXPECT_DOUBLE_EQ(c, 6.0);
+  }
+  { // a·a with gamma=1: N_unique=2, opTerm=2, C_repeat=(2-1)*wAtom=1 -> 2+2+1 = 5
+    Factory F;
+    CostModel cm = CostModel::uniform();
+    cm.gamma = 1.0;
+    auto imp = ean::importCanonical<int>({F.concat(F.atom(0), F.atom(0))});
+    double c = ean::reuseAwareExtract(imp.g, imp.roots, cm, o0).dagCost;
+    EXPECT_DOUBLE_EQ(c, 5.0);
+  }
+}
+
+// A cyclic e-graph (star + its unfolding referencing itself) must extract to a
+// finite expression and terminate.
+TEST(EanBatchExtract, CycleSafeExtractsFiniteRepresentative) {
+  Factory F;
+  Ref a = F.atom(0);
+  Ref starA = F.star(a);
+  const Mat before = evalRef(starA);
+
+  auto imp = ean::importCanonical<int>({starA});
+  const Id starCls = imp.g.find(imp.roots[0]);
+  const PathLang &starNode = imp.g[starCls].nodes.front();
+  ASSERT_TRUE(ean::isStar(starNode));
+  const Id aCls = imp.g.find(starNode.children()[0]);
+
+  // Add the star unfolding  1 ⊕ a·(a*)  and merge it into the star class,
+  // making the e-graph intentionally cyclic (the unfold refers back to a*).
+  const Id aStar = ean::canon::seq(imp.g, {aCls, starCls});    // a·(a*)
+  const Id unfold =
+      ean::canon::join(imp.g, {ean::canon::oneId(imp.g), aStar}); // 1 ⊕ a·(a*)
+  imp.g.uniteChecked(starCls, unfold);
+  imp.g.rebuild();
+
+  // Extraction must terminate and pick the finite star representative.
+  auto res = ean::reuseAwareExtract(imp.g, {imp.g.find(starCls)},
+                                    CostModel::uniform(), ExtractOptions{});
+  const PathLang &chosen = res.chosen.at(imp.g.find(starCls).value());
+  EXPECT_TRUE(ean::isStar(chosen)) << "extractor picked the cyclic unfold";
+
+  Factory G;
+  ean::PickFn pick = [&](Id c) -> const PathLang & {
+    return res.chosen.at(imp.g.find(c).value());
+  };
+  Ref out = ean::exportTree<int>(imp.g, imp.atoms, imp.g.find(starCls), G, pick);
+  EXPECT_TRUE(evalRef(out) == before);
+}
+
+// The reuse loop never yields a worse Eq. 5 cost than the initial tree solution
+// (safety net), and export stays semantics-preserving.
+TEST(EanBatchExtract, ReuseNeverWorseThanTree) {
+  Factory F;
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3);
+  Ref p = F.unite(a, b);
+  Ref r1 = F.unite(F.concat(p, c), F.concat(p, d));
+  Ref r2 = F.concat(p, c);
+  std::vector<Ref> R = {r1, r2};
+  std::vector<Mat> before = {evalRef(r1), evalRef(r2)};
+
+  auto imp = ean::importCanonical<int>(R);
+  ean::factorizeToFixpoint(imp.g, LawProfile::kleeneAlgebra());
+
+  CostModel cm = CostModel::uniform();
+  ExtractOptions o0;
+  o0.reuseIters = 0;
+  ExtractOptions o3;
+  o3.reuseIters = 3;
+  const double cTree = ean::reuseAwareExtract(imp.g, imp.roots, cm, o0).dagCost;
+  const double cReuse = ean::reuseAwareExtract(imp.g, imp.roots, cm, o3).dagCost;
+  EXPECT_LE(cReuse, cTree + 1e-9);
+
+  auto res = ean::reuseAwareExtract(imp.g, imp.roots, cm, o3);
+  Factory G;
+  ean::PickFn pick = [&](Id id) -> const PathLang & {
+    return res.chosen.at(imp.g.find(id).value());
+  };
+  auto out = ean::exportBatch<int>(imp, G, pick);
+  ASSERT_EQ(out.size(), 2u);
+  EXPECT_TRUE(evalRef(out[0]) == before[0]);
+  EXPECT_TRUE(evalRef(out[1]) == before[1]);
+}
+
+// Full ean() with reuse-aware extraction reduces nodes and preserves semantics
+// in both plateau modes.
+TEST(EanBatchExtract, EndToEndBothPlateauModes) {
+  for (ExtractOptions::PlateauCost mode :
+       {ExtractOptions::PlateauCost::Tree, ExtractOptions::PlateauCost::Dag}) {
+    Factory F;
+    Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3), e = F.atom(4);
+    Ref r = F.unite(F.unite(seq3(F, a, b, c), seq3(F, a, b, d)), seq3(F, a, b, e));
+    const Mat before = evalRef(r);
+    const std::size_t origUnique = countUnique({r});
+
+    ExtractOptions opts;
+    opts.plateauMode = mode;
+    Factory G;
+    auto out = ean::ean<int>({r}, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                             ean::Budget::unbounded(), G, nullptr, opts);
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_TRUE(evalRef(out[0]) == before);
+    EXPECT_LE(countUnique(out), origUnique);
+  }
+}
+
+// Decisive byte-identical guard for the work-queue rewrite of cycleSafeExtract:
+// the parent-pointer worklist must compute the SAME least fixpoint (identical
+// chosen node and cost per class) as the previous whole-graph pass relaxation.
+// A local copy of the naive relaxation is the reference oracle.
+namespace {
+ean::detail::RelaxState naiveCycleSafe(ean::Graph &g, std::size_t passes) {
+  ean::PathCostFn wf(CostModel::uniform());
+  auto wNode = [&](const PathLang &n) { return wf.opWeight(n); };
+  auto disc = [](std::uint32_t) { return 1.0; };
+  ean::detail::RelaxState st;
+  const auto ids = g.classIds();
+  for (std::size_t pass = 0; pass < passes; ++pass) {
+    bool changed = false;
+    for (Id c0 : ids) {
+      const std::uint32_t cid = g.find(c0).value();
+      const auto &cls = g[c0];
+      for (const PathLang &n : cls.nodes) {
+        double cost = wNode(n);
+        bool eligible = true;
+        for (Id q : n.children()) {
+          const std::uint32_t qid = g.find(q).value();
+          const double cc = st.at(qid);
+          if (cc == ean::detail::kInf) {
+            eligible = false;
+            break;
+          }
+          cost += cc * disc(qid);
+        }
+        if (eligible && cost < st.at(cid)) {
+          st.cost[cid] = cost;
+          st.chosen[cid] = n;
+          changed = true;
+        }
+      }
+    }
+    if (!changed)
+      break;
+  }
+  return st;
+}
+} // namespace
+
+TEST(EanBatchExtract, WorklistExtractMatchesNaive) {
+  ean::PathCostFn wf(CostModel::uniform());
+  auto wNode = [&](const PathLang &n) { return wf.opWeight(n); };
+  auto disc = [](std::uint32_t) { return 1.0; };
+
+  for (int t = 0; t < 300; ++t) {
+    Factory F;
+    std::vector<Ref> R;
+    const int k = 1 + static_cast<int>(rnd() % 3);
+    for (int i = 0; i < k; ++i)
+      R.push_back(randExpr(F, 4));
+
+    auto imp = ean::importCanonical<int>(R);
+    // Grow alternatives so classes carry multiple nodes (non-trivial extraction).
+    ean::factorizeToFixpoint(imp.g, LawProfile::kleeneAlgebra());
+    imp.g.rebuild();
+
+    const std::size_t passes = imp.g.numberOfClasses() + 1;
+    ean::detail::RelaxState wl =
+        ean::detail::cycleSafeExtract(imp.g, wNode, disc, passes);
+    ean::detail::RelaxState nv = naiveCycleSafe(imp.g, passes);
+
+    ASSERT_EQ(wl.cost.size(), nv.cost.size()) << "trial " << t;
+    for (const auto &kv : nv.cost) {
+      auto it = wl.cost.find(kv.first);
+      ASSERT_NE(it, wl.cost.end()) << "trial " << t << " class " << kv.first;
+      EXPECT_DOUBLE_EQ(it->second, kv.second) << "trial " << t;
+      auto cit = wl.chosen.find(kv.first);
+      auto nit = nv.chosen.find(kv.first);
+      ASSERT_NE(cit, wl.chosen.end());
+      ASSERT_NE(nit, nv.chosen.end());
+      EXPECT_TRUE(cit->second == nit->second)
+          << "trial " << t << " class " << kv.first << ": chosen node differs";
+    }
+  }
+}
+
+TEST(EanBatchExtract, RandomizedDifferential) {
+  for (int t = 0; t < 400; ++t) {
+    Factory F;
+    std::vector<Ref> R;
+    std::vector<Mat> before;
+    const int k = 1 + static_cast<int>(rnd() % 3);
+    for (int i = 0; i < k; ++i) {
+      Ref e = randExpr(F, 4);
+      R.push_back(e);
+      before.push_back(evalRef(e));
+    }
+    ExtractOptions opts;
+    opts.reuseIters = 3;
+    opts.plateauMode = (t % 2) ? ExtractOptions::PlateauCost::Dag
+                               : ExtractOptions::PlateauCost::Tree;
+    ean::Budget b = ean::Budget::unbounded();
+    b.roundLimit = 200;
+
+    Factory G;
+    auto out = ean::ean<int>(R, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                             b, G, nullptr, opts);
+    ASSERT_EQ(out.size(), R.size()) << "trial " << t;
+    for (std::size_t i = 0; i < R.size(); ++i) {
+      EXPECT_TRUE(evalRef(out[i]) == before[i]) << "trial " << t << " root " << i;
+    }
+  }
+}

--- a/tests/unit/Dataflow/APA/EAN/BoolKleene.h
+++ b/tests/unit/Dataflow/APA/EAN/BoolKleene.h
@@ -1,0 +1,79 @@
+#ifndef LOTUS_TEST_EAN_BOOLKLEENE_H_
+#define LOTUS_TEST_EAN_BOOLKLEENE_H_
+
+// A concrete Kleene algebra used as a differential oracle for EAN tests:
+// atoms map deterministically to boolean 3x3 matrices; join = OR, seq = boolean
+// matmul, star = reflexive-transitive closure, zero = zero matrix, one =
+// identity. Equality of the interpretation before/after an EAN transform
+// witnesses semantic preservation. This algebra satisfies left/right
+// distributivity, so it is a valid oracle for factorization.
+
+#include <array>
+#include <cstdint>
+
+#include "Dataflow/APA/Core/PathExpr.h"
+
+namespace lotus_test_ean {
+
+constexpr int N = 3;
+struct Mat {
+  std::array<std::array<bool, N>, N> a{};
+  bool operator==(const Mat &o) const { return a == o.a; }
+  bool operator!=(const Mat &o) const { return !(*this == o); }
+};
+
+inline Mat zeroM() { return Mat{}; }
+inline Mat oneM() {
+  Mat m;
+  for (int i = 0; i < N; ++i) m.a[i][i] = true;
+  return m;
+}
+inline Mat orM(const Mat &x, const Mat &y) {
+  Mat r;
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j) r.a[i][j] = x.a[i][j] || y.a[i][j];
+  return r;
+}
+inline Mat mulM(const Mat &x, const Mat &y) {
+  Mat r;
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j) {
+      bool s = false;
+      for (int k = 0; k < N; ++k) s = s || (x.a[i][k] && y.a[k][j]);
+      r.a[i][j] = s;
+    }
+  return r;
+}
+inline Mat closureM(const Mat &x) {
+  Mat r = oneM(), p = oneM();
+  for (int it = 0; it < N + 1; ++it) {
+    p = mulM(p, x);
+    r = orM(r, p);
+  }
+  return r;
+}
+inline Mat gen(int id) {
+  Mat m;
+  std::uint32_t h = static_cast<std::uint32_t>(id) * 2654435761u + 0x9e3779b9u;
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j) m.a[i][j] = ((h >> (i * N + j)) & 1u) != 0;
+  return m;
+}
+
+// Interpret a PathExprFactory<int> expression (atoms are generator indices).
+inline Mat evalRef(const typename elimination::PathExprFactory<int>::Ref &e) {
+  using Kind = elimination::PathExprFactory<int>::Kind;
+  switch (e->K) {
+  case Kind::Zero: return zeroM();
+  case Kind::One: return oneM();
+  case Kind::Atom: return gen(*e->Transfer);
+  case Kind::Union: return orM(evalRef(e->L), evalRef(e->R));
+  case Kind::Concat: return mulM(evalRef(e->L), evalRef(e->R));
+  case Kind::Star: return closureM(evalRef(e->L));
+  }
+  return zeroM();
+}
+
+} // namespace lotus_test_ean
+
+#endif // LOTUS_TEST_EAN_BOOLKLEENE_H_

--- a/tests/unit/Dataflow/APA/EAN/EanGraphEval.h
+++ b/tests/unit/Dataflow/APA/EAN/EanGraphEval.h
@@ -1,0 +1,71 @@
+#ifndef LOTUS_TEST_EAN_GRAPHEVAL_H_
+#define LOTUS_TEST_EAN_GRAPHEVAL_H_
+
+// Graph-side interpreter for the boolean-matrix Kleene oracle: evaluates e-nodes
+// directly on the e-graph so a test can assert that EVERY e-node in EVERY class
+// agrees with its class representative — i.e. a rewrite never united a
+// semantically different node into a class. Complements Ref-level evalRef.
+
+#include <cstdint>
+#include <functional>
+#include <unordered_map>
+
+#include "BoolKleene.h"
+#include "Dataflow/APA/EAN/AtomTable.h"
+#include "Dataflow/APA/EAN/Canonical.h"
+#include "Dataflow/APA/EAN/PathLang.h"
+
+namespace lotus_test_ean {
+
+namespace ean = elimination::ean;
+
+inline Mat evalClass(ean::Graph &g, const ean::AtomTable<int> &atoms,
+                     ean::Id c, std::unordered_map<std::uint32_t, Mat> &memo);
+
+inline Mat evalNode(ean::Graph &g, const ean::AtomTable<int> &atoms,
+                    const ean::PathLang &n,
+                    std::unordered_map<std::uint32_t, Mat> &memo) {
+  if (ean::isZero(n)) return zeroM();
+  if (ean::isOne(n)) return oneM();
+  if (ean::isAtom(n)) return gen(*atoms.atom(ean::parseAtomId(n))->Transfer);
+  if (ean::isStar(n)) return closureM(evalClass(g, atoms, n.children()[0], memo));
+  if (ean::isJoin(n)) {
+    Mat m = zeroM();
+    for (ean::Id ch : n.children()) m = orM(m, evalClass(g, atoms, ch, memo));
+    return m;
+  }
+  Mat m = oneM(); // seq
+  for (ean::Id ch : n.children()) m = mulM(m, evalClass(g, atoms, ch, memo));
+  return m;
+}
+
+inline Mat evalClass(ean::Graph &g, const ean::AtomTable<int> &atoms,
+                     ean::Id c, std::unordered_map<std::uint32_t, Mat> &memo) {
+  c = g.find(c);
+  auto it = memo.find(c.value());
+  if (it != memo.end()) return it->second;
+  Mat m = evalNode(g, atoms, g[c].nodes.front(), memo);
+  memo[c.value()] = m;
+  return m;
+}
+
+// Every e-node in every class must interpret to its class representative.
+inline bool allClassesConsistent(ean::Graph &g,
+                                 const ean::AtomTable<int> &atoms) {
+  std::unordered_map<std::uint32_t, Mat> memo;
+  for (ean::Id c : g.classIds()) {
+    (void)evalClass(g, atoms, g.find(c), memo);
+  }
+  for (ean::Id c : g.classIds()) {
+    const ean::Id cc = g.find(c);
+    const Mat ref = memo[cc.value()];
+    for (const ean::PathLang &n : g[cc].nodes) {
+      if (evalNode(g, atoms, n, memo) != ref) return false;
+    }
+  }
+  return true;
+}
+
+} // namespace lotus_test_ean
+
+#endif // LOTUS_TEST_EAN_GRAPHEVAL_H_

--- a/tests/unit/Dataflow/APA/EAN/EvalExportTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/EvalExportTest.cpp
@@ -1,0 +1,560 @@
+// EAN evaluation DATA EXPORT (paper §IV). This harness runs the fillable,
+// corpus-independent parts of the evaluation on a synthetic path-expression
+// corpus and writes machine-readable CSVs that map cell-for-cell onto the
+// paper's tables. Everything here is LLVM-free (PathExprFactory<int> +
+// boolean-matrix Kleene oracle), so it runs in the isolated build.
+//
+// What it fills TODAY (see docs/eval/RESULTS.md for the cell mapping):
+//   * Table IV  — Synthetic corpus row(s): roots, DAG nodes, star nodes.
+//   * Table VI  — EAN row: geo-mean per-subject ratios (nodes/edges/tree/
+//                 sequence/stars) + absolute sharing before/after.
+//   * RQ1 text  — exact comparison / unequal-fact / missing-root counts.
+//   * Table VIII— ablation rows that correspond to IMPLEMENTED mechanisms
+//                 (factorization, star rules, uniform vs profiled tree cost,
+//                 reuse-aware vs tree extraction). Deferred mechanisms
+//                 (guarded expansion, phase schedule) are emitted as N/A.
+//   * RQ4       — budget sweep (final nodes vs peak e-nodes) → the knee.
+//
+// What it does NOT fill (needs machinery not yet built — clearly deferred, not
+// faked): Greedy/Order/Order+EAN configs, real-LLVM Table IV rows, and all of
+// RQ2 (Table VII timing) / RQ3 (Order complementarity).
+
+#include "Dataflow/APA/EAN/DagStats.h"
+#include "Dataflow/APA/EAN/EAN.h"
+#include "Dataflow/APA/EAN/Greedy.h"
+
+#include "BoolKleene.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace lotus_test_ean;
+namespace ean = elimination::ean;
+using ean::Budget;
+using ean::CostModel;
+using ean::DagStats;
+using ean::ExtractOptions;
+using ean::Law;
+using ean::LawProfile;
+using Factory = elimination::PathExprFactory<int>;
+using Ref = Factory::Ref;
+
+// ---------------------------------------------------------------- corpus ----
+struct Subject {
+  std::string family;
+  std::string label;
+  std::vector<Ref> roots;
+  Factory *F; // owns the roots
+};
+
+Ref seqOf(Factory &F, const std::vector<Ref> &xs) {
+  Ref acc = xs.front();
+  for (std::size_t i = 1; i < xs.size(); ++i) acc = F.concat(acc, xs[i]);
+  return acc;
+}
+Ref unionOf(Factory &F, const std::vector<Ref> &xs) {
+  Ref acc = xs.front();
+  for (std::size_t i = 1; i < xs.size(); ++i) acc = F.unite(acc, xs[i]);
+  return acc;
+}
+
+// k branches sharing an L-atom prefix: ⊕_i (p0·…·p_{L-1}·c_i).
+std::vector<Ref> repeatedPrefix(Factory &F, int k, int L) {
+  std::vector<Ref> pre;
+  for (int i = 0; i < L; ++i) pre.push_back(F.atom(i));
+  std::vector<Ref> br;
+  for (int i = 0; i < k; ++i) {
+    std::vector<Ref> s = pre;
+    s.push_back(F.atom(1000 + i));
+    br.push_back(seqOf(F, s));
+  }
+  return {unionOf(F, br)};
+}
+// k branches sharing an L-atom suffix: ⊕_i (c_i·s0·…·s_{L-1}).
+std::vector<Ref> repeatedSuffix(Factory &F, int k, int L) {
+  std::vector<Ref> suf;
+  for (int i = 0; i < L; ++i) suf.push_back(F.atom(i));
+  std::vector<Ref> br;
+  for (int i = 0; i < k; ++i) {
+    std::vector<Ref> s;
+    s.push_back(F.atom(1000 + i));
+    for (Ref x : suf) s.push_back(x);
+    br.push_back(seqOf(F, s));
+  }
+  return {unionOf(F, br)};
+}
+// m roots each = sharedQ·atom_j, where sharedQ = (a·b·c)⊕(a·b·d) is factorable.
+std::vector<Ref> crossRootReuse(Factory &F, int m) {
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3);
+  Ref q = F.unite(seqOf(F, {a, b, c}), seqOf(F, {a, b, d}));
+  std::vector<Ref> roots;
+  for (int j = 0; j < m; ++j) roots.push_back(F.concat(q, F.atom(2000 + j)));
+  return roots;
+}
+// Loop shapes exercising sliding / star handling.
+std::vector<Ref> loopFamily(Factory &F, int variant) {
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2);
+  if (variant == 0) return {F.concat(F.star(F.concat(a, b)), a)}; // (a·b)*·a
+  if (variant == 1)
+    return {F.concat(F.star(F.concat(a, F.star(F.concat(b, c)))), a)};
+  // batch of two loop roots sharing (a·b)
+  return {F.concat(F.star(F.concat(a, b)), a),
+          F.concat(F.star(F.concat(a, b)), c)};
+}
+
+// Expanded union of all root-to-leaf paths of a full binary trie of the given
+// depth: 2^depth branches, each a length-`depth` sequence of per-edge atoms
+// shared with its siblings. Fully factoring it back into the trie takes ~depth
+// saturation rounds (each round peels one level), so this family exposes a
+// multi-round budget knee where the single-round families do not.
+void triePaths(Factory &F, int id, int level, int depth, std::vector<Ref> &cur,
+               std::vector<Ref> &out) {
+  cur.push_back(F.atom(id));
+  if (level == depth) {
+    out.push_back(seqOf(F, cur));
+  } else {
+    triePaths(F, id * 2 + 1, level + 1, depth, cur, out);
+    triePaths(F, id * 2 + 2, level + 1, depth, cur, out);
+  }
+  cur.pop_back();
+}
+std::vector<Ref> nestedTrie(Factory &F, int depth) {
+  std::vector<Ref> cur, leaves;
+  triePaths(F, 1, 1, depth, cur, leaves);
+  return {unionOf(F, leaves)};
+}
+
+// Deterministic PRNG (no Date/rand — reproducible corpus).
+std::uint64_t g_seed = 0xEA9C0FFEEULL;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+Ref randExpr(Factory &F, int depth) {
+  if (depth <= 0 || (rnd() % 3 == 0)) return F.atom(static_cast<int>(rnd() % 6));
+  switch (rnd() % 4) {
+  case 0: return F.unite(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 1: return F.concat(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 2: return F.star(randExpr(F, depth - 1));
+  default: return F.atom(static_cast<int>(rnd() % 6));
+  }
+}
+
+// Build the whole corpus. Each Subject owns its Factory (kept alive in `pool`).
+void buildCorpus(std::vector<Factory> &pool, std::vector<Subject> &out) {
+  auto push = [&](const std::string &fam, const std::string &lab,
+                  std::vector<Ref> roots, Factory *f) {
+    out.push_back(Subject{fam, lab, std::move(roots), f});
+  };
+
+  for (int k : {2, 4, 8, 16})
+    for (int L : {2, 4, 8}) {
+      pool.emplace_back();
+      Factory *f = &pool.back();
+      push("RepeatedPrefix", "P" + std::to_string(k) + "x" + std::to_string(L),
+           repeatedPrefix(*f, k, L), f);
+    }
+  for (int k : {2, 4, 8, 16})
+    for (int L : {2, 4, 8}) {
+      pool.emplace_back();
+      Factory *f = &pool.back();
+      push("RepeatedSuffix", "S" + std::to_string(k) + "x" + std::to_string(L),
+           repeatedSuffix(*f, k, L), f);
+    }
+  for (int m : {2, 4, 6, 8, 12}) {
+    pool.emplace_back();
+    Factory *f = &pool.back();
+    push("CrossRootReuse", "X" + std::to_string(m), crossRootReuse(*f, m), f);
+  }
+  for (int v : {0, 1, 2}) {
+    pool.emplace_back();
+    Factory *f = &pool.back();
+    push("LoopFamily", "L" + std::to_string(v), loopFamily(*f, v), f);
+  }
+  for (int d : {3, 4, 5}) {
+    pool.emplace_back();
+    Factory *f = &pool.back();
+    push("NestedTrie", "T" + std::to_string(d), nestedTrie(*f, d), f);
+  }
+  // Random-but-seeded subjects for statistical mass in the geo-means.
+  for (int t = 0; t < 40; ++t) {
+    pool.emplace_back();
+    Factory *f = &pool.back();
+    std::vector<Ref> roots;
+    const int k = 1 + static_cast<int>(rnd() % 3);
+    for (int i = 0; i < k; ++i) roots.push_back(randExpr(*f, 5));
+    push("Random", "R" + std::to_string(t), std::move(roots), f);
+  }
+}
+
+// -------------------------------------------------------------- helpers -----
+// Geometric mean of a set of positive ratios (log-space).
+struct GeoMean {
+  double sumLog = 0.0;
+  std::size_t n = 0;
+  std::size_t skippedZero = 0;
+  void add(double before, double after) {
+    if (before <= 0.0) return; // metric absent in this subject
+    if (after <= 0.0) {        // fully eliminated — record separately
+      ++skippedZero;
+      return;
+    }
+    sumLog += std::log(after / before);
+    ++n;
+  }
+  double value() const { return n ? std::exp(sumLog / static_cast<double>(n)) : 1.0; }
+};
+
+std::string outDir() {
+  const char *d = std::getenv("EAN_EVAL_OUT");
+  return d && *d ? std::string(d) : std::string(".");
+}
+std::ofstream open(const std::string &name) {
+  std::ofstream os(outDir() + "/" + name);
+  return os;
+}
+
+// Run EAN once and return the exported roots + after-stats + parity flag.
+struct RunOut {
+  std::vector<Ref> roots;
+  DagStats after;
+  bool parity = true;
+  ean::SaturationStats stats;
+};
+RunOut runEAN(const std::vector<Ref> &R, const LawProfile &L, const CostModel &C,
+              const Budget &B, const ExtractOptions &opts) {
+  std::vector<Mat> want;
+  for (const auto &r : R) want.push_back(evalRef(r));
+  Factory G;
+  ean::SaturationStats stats;
+  auto out = ean::ean<int>(R, L, C, B, G, &stats, opts);
+  RunOut ro;
+  ro.stats = stats;
+  ro.parity = (out.size() == R.size());
+  for (std::size_t i = 0; i < out.size() && i < want.size(); ++i)
+    if (evalRef(out[i]) != want[i]) ro.parity = false;
+  ro.after = ean::computeDagStats<int>(out);
+  ro.roots = std::move(out);
+  // Keep exported roots alive by holding G in a static? No — computeDagStats
+  // already read the structure; but `roots` point into G which dies here.
+  // We only need `after` (already materialised) and parity, so drop roots.
+  ro.roots.clear();
+  (void)ro.roots;
+  return ro;
+}
+
+} // namespace
+
+// The single export test. Writes all CSVs and asserts global correctness.
+TEST(EanEvalExport, WriteAllTables) {
+  std::vector<Factory> pool;
+  pool.reserve(128);
+  std::vector<Subject> corpus;
+  buildCorpus(pool, corpus);
+
+  // ---- Table IV: corpus before normalization, aggregated per family --------
+  struct FamAgg {
+    std::size_t subjects = 0, roots = 0, dagNodes = 0, starNodes = 0,
+                edges = 0;
+    double tree = 0.0;
+  };
+  std::map<std::string, FamAgg> fam;
+  std::vector<std::string> famOrder;
+
+  // ---- Table VI: EAN-row geo-means + sharing -------------------------------
+  GeoMean gmNodes, gmEdges, gmTree, gmSeq, gmStars;
+  double shareBeforeSum = 0.0, shareAfterSum = 0.0;
+  std::size_t shareN = 0;
+  // Greedy-row geo-means (deterministic one-pass simplification, reuseIters=0).
+  GeoMean gmGNodes, gmGEdges, gmGTree, gmGSeq, gmGStars;
+  double shareGAfterSum = 0.0;
+
+  // ---- RQ1 correctness counters --------------------------------------------
+  std::size_t comparisons = 0, unequal = 0, missingRoots = 0;
+
+  const LawProfile FULL = LawProfile::kleeneAlgebra();
+  const CostModel UNI = CostModel::uniform();
+  ExtractOptions REUSE;
+  REUSE.reuseIters = 3;
+
+  for (auto &s : corpus) {
+    if (std::find(famOrder.begin(), famOrder.end(), s.family) == famOrder.end())
+      famOrder.push_back(s.family);
+    DagStats before = ean::computeDagStats<int>(s.roots);
+
+    // parity per root (RQ1 comparison count)
+    std::vector<Mat> want;
+    for (const auto &r : s.roots) want.push_back(evalRef(r));
+
+    Factory G;
+    ean::SaturationStats stats;
+    auto out = ean::ean<int>(s.roots, FULL, UNI, Budget::unbounded(), G, &stats,
+                             REUSE);
+    if (out.size() != s.roots.size()) ++missingRoots;
+    const std::size_t nCmp = std::min(out.size(), want.size());
+    for (std::size_t i = 0; i < nCmp; ++i) {
+      ++comparisons;
+      if (evalRef(out[i]) != want[i]) ++unequal;
+    }
+    DagStats after = ean::computeDagStats<int>(out);
+
+    FamAgg &fa = fam[s.family];
+    ++fa.subjects;
+    fa.roots += s.roots.size();
+    fa.dagNodes += before.uniqueNodes;
+    fa.starNodes += before.stars;
+    fa.edges += before.uniqueEdges;
+    fa.tree += before.expandedTree;
+
+    gmNodes.add(before.uniqueNodes, after.uniqueNodes);
+    gmEdges.add(before.uniqueEdges, after.uniqueEdges);
+    gmTree.add(before.expandedTree, after.expandedTree);
+    gmSeq.add(before.concats, after.concats);
+    gmStars.add(before.stars, after.stars);
+    shareBeforeSum += before.sharing();
+    shareAfterSum += after.sharing();
+    ++shareN;
+
+    // Greedy row: deterministic one-pass simplification (safe laws, uniform
+    // cost, reuseIters=0, monotone). Semantics-preserving — assert parity.
+    Factory Gg;
+    auto gout = elimination::greedySimplify<int>(s.roots, Gg);
+    ASSERT_EQ(gout.size(), s.roots.size()) << s.family << "/" << s.label;
+    for (std::size_t i = 0; i < gout.size() && i < want.size(); ++i)
+      EXPECT_TRUE(evalRef(gout[i]) == want[i]) << "greedy " << s.family;
+    DagStats gafter = ean::computeDagStats<int>(gout);
+    gmGNodes.add(before.uniqueNodes, gafter.uniqueNodes);
+    gmGEdges.add(before.uniqueEdges, gafter.uniqueEdges);
+    gmGTree.add(before.expandedTree, gafter.expandedTree);
+    gmGSeq.add(before.concats, gafter.concats);
+    gmGStars.add(before.stars, gafter.stars);
+    shareGAfterSum += gafter.sharing();
+  }
+
+  // Additional randomized differential over random law subsets (RQ1 "we also
+  // run N differential tests on randomly generated DAGs and law profiles").
+  const int DIFF = 3000;
+  std::size_t diffUnequal = 0;
+  const Law laws[] = {Law::LeftDistributive, Law::RightDistributive,
+                      Law::Sliding};
+  for (int t = 0; t < DIFF; ++t) {
+    Factory F;
+    std::vector<Ref> R;
+    std::vector<Mat> want;
+    const int k = 1 + static_cast<int>(rnd() % 3);
+    for (int i = 0; i < k; ++i) {
+      Ref e = randExpr(F, 4);
+      R.push_back(e);
+      want.push_back(evalRef(e));
+    }
+    LawProfile Lp;
+    for (Law law : laws)
+      if (rnd() & 1) Lp.enable(law);
+    Factory G;
+    Budget b = Budget::unbounded();
+    b.roundLimit = 200;
+    auto out = ean::ean<int>(R, Lp, UNI, b, G);
+    if (out.size() != R.size()) {
+      ++missingRoots;
+      continue;
+    }
+    for (std::size_t i = 0; i < out.size(); ++i) {
+      ++comparisons;
+      if (evalRef(out[i]) != want[i]) {
+        ++unequal;
+        ++diffUnequal;
+      }
+    }
+  }
+
+  // ===================== write Table IV =====================================
+  {
+    auto os = open("table4_corpus.csv");
+    os << "family,subjects,roots,dag_nodes,star_nodes,edges,expanded_tree\n";
+    std::size_t tS = 0, tR = 0, tN = 0, tSt = 0, tE = 0;
+    double tT = 0;
+    for (const auto &f : famOrder) {
+      const FamAgg &a = fam[f];
+      os << f << "," << a.subjects << "," << a.roots << "," << a.dagNodes << ","
+         << a.starNodes << "," << a.edges << "," << a.tree << "\n";
+      tS += a.subjects; tR += a.roots; tN += a.dagNodes; tSt += a.starNodes;
+      tE += a.edges; tT += a.tree;
+    }
+    os << "Synthetic(total)," << tS << "," << tR << "," << tN << "," << tSt
+       << "," << tE << "," << tT << "\n";
+  }
+
+  // ===================== write Table VI (EAN row) ===========================
+  {
+    auto os = open("table6_ir_quality.csv");
+    os << "configuration,unique_nodes,dag_edges,tree_size,sequence,stars,"
+          "sharing_before,sharing_after\n";
+    os << "EAN," << gmNodes.value() << "," << gmEdges.value() << ","
+       << gmTree.value() << "," << gmSeq.value() << "," << gmStars.value() << ","
+       << (shareN ? shareBeforeSum / shareN : 0.0) << ","
+       << (shareN ? shareAfterSum / shareN : 0.0) << "\n";
+    os << "Greedy," << gmGNodes.value() << "," << gmGEdges.value() << ","
+       << gmGTree.value() << "," << gmGSeq.value() << "," << gmGStars.value()
+       << "," << (shareN ? shareBeforeSum / shareN : 0.0) << ","
+       << (shareN ? shareGAfterSum / shareN : 0.0) << "\n";
+    os << "Order,see table6_order_rows.csv,,,,,,\n";
+    os << "Order+EAN,see table6_order_rows.csv,,,,,,\n";
+  }
+
+  // ===================== write RQ1 correctness ==============================
+  {
+    auto os = open("rq1_correctness.csv");
+    os << "metric,value\n";
+    os << "corpus_subjects," << corpus.size() << "\n";
+    os << "differential_tests," << DIFF << "\n";
+    os << "total_comparisons," << comparisons << "\n";
+    os << "unequal_facts," << unequal << "\n";
+    os << "differential_unequal," << diffUnequal << "\n";
+    os << "missing_roots," << missingRoots << "\n";
+    os << "semantic_timeouts,0\n";
+    os << "geo_mean_unique_node_ratio," << gmNodes.value() << "\n";
+  }
+
+  // ===================== Table VIII: ablation vs full EAN ====================
+  // full EAN reference: kleene laws + profiled cost + reuse-aware extraction.
+  {
+    const CostModel PRO = CostModel::profiled();
+    ExtractOptions tree0;
+    tree0.reuseIters = 0;
+    const int REPS = 5; // wall-clock is noisy on tiny synthetic subjects
+
+    GeoMean gNoFactor, gNoStar, gNoExpand, gNoSched, gUniTree, gProTree,
+        gReuseVsTree;
+    double tFull = 0, tNoFactor = 0, tNoStar = 0, tNoExpand = 0, tNoSched = 0,
+           tUni = 0, tPro = 0;
+
+    // Run a variant REPS times, accumulate wall-clock into `acc`, return the
+    // last RunOut (stats/parity are deterministic across reps).
+    auto timed = [&](const std::vector<Ref> &R, const LawProfile &L,
+                     const CostModel &C, const ExtractOptions &o,
+                     double &acc) -> RunOut {
+      const auto t0 = std::chrono::steady_clock::now();
+      RunOut ro;
+      for (int i = 0; i < REPS; ++i) {
+        ro = runEAN(R, L, C, Budget::unbounded(), o);
+      }
+      acc += std::chrono::duration<double>(std::chrono::steady_clock::now() - t0)
+                 .count();
+      return ro;
+    };
+
+    for (auto &s : corpus) {
+      auto full = timed(s.roots, FULL, PRO, REUSE, tFull);
+      const double base = static_cast<double>(full.after.uniqueNodes);
+
+      LawProfile noFac = FULL;
+      noFac.disable(Law::LeftDistributive).disable(Law::RightDistributive);
+      auto rNoFac = timed(s.roots, noFac, PRO, REUSE, tNoFactor);
+
+      LawProfile noStar = FULL;
+      noStar.disable(Law::Sliding);
+      auto rNoStar = timed(s.roots, noStar, PRO, REUSE, tNoStar);
+
+      // No guarded expansion: Explore phase disabled (growth cap 0 rejects every
+      // expansion) while all other mechanisms stay on.
+      ExtractOptions noExpand = REUSE;
+      noExpand.expandGrowthCap = 0;
+      auto rNoExp = timed(s.roots, FULL, PRO, noExpand, tNoExpand);
+
+      // No phase schedule: apply every rewrite family together each round.
+      ExtractOptions noSched = REUSE;
+      noSched.scheduled = false;
+      auto rNoSch = timed(s.roots, FULL, PRO, noSched, tNoSched);
+
+      auto rUni = timed(s.roots, FULL, UNI, tree0, tUni);
+      auto rPro = timed(s.roots, FULL, PRO, tree0, tPro);
+
+      EXPECT_TRUE(full.parity && rNoFac.parity && rNoStar.parity &&
+                  rNoExp.parity && rNoSch.parity && rUni.parity && rPro.parity)
+          << s.family << "/" << s.label;
+
+      gNoFactor.add(base, rNoFac.after.uniqueNodes);
+      gNoStar.add(base, rNoStar.after.uniqueNodes);
+      gNoExpand.add(base, rNoExp.after.uniqueNodes);
+      gNoSched.add(base, rNoSch.after.uniqueNodes);
+      gUniTree.add(base, rUni.after.uniqueNodes);
+      gProTree.add(base, rPro.after.uniqueNodes);
+      // reuse-aware (base) vs profiled tree: ratio base/proTree (≤1 = reuse wins)
+      gReuseVsTree.add(rPro.after.uniqueNodes, base);
+    }
+
+    // End-to-end time ratio vs full EAN (aggregate wall-clock over the corpus;
+    // >1 = slower than full EAN, <1 = faster). Synthetic-corpus proxy; the real
+    // timing story is Table VII on the LLVM corpus.
+    auto tr = [&](double t) { return tFull > 0 ? t / tFull : 0.0; };
+
+    auto os = open("table8_ablation.csv");
+    os << "variant,final_nodes_ratio_vs_fullEAN,end2end_ratio_vs_fullEAN,note\n";
+    os << "No factorization," << gNoFactor.value() << "," << tr(tNoFactor)
+       << ",disable Left/Right distributivity\n";
+    os << "No star rules," << gNoStar.value() << "," << tr(tNoStar)
+       << ",disable sliding\n";
+    os << "No guarded expansion," << gNoExpand.value() << "," << tr(tNoExpand)
+       << ",disable Explore phase (expandGrowthCap=0)\n";
+    os << "No phase schedule," << gNoSched.value() << "," << tr(tNoSched)
+       << ",unscheduled: all rewrite families each round\n";
+    os << "Uniform tree cost," << gUniTree.value() << "," << tr(tUni)
+       << ",uniform weights + tree extraction (reuseIters=0)\n";
+    os << "Profiled tree cost," << gProTree.value() << "," << tr(tPro)
+       << ",profiled weights + tree extraction (reuseIters=0)\n";
+    os << "Reuse-aware/ProfiledTree," << gReuseVsTree.value() << ",,"
+       << "full-EAN nodes / profiled-tree nodes (<=1 reuse wins)\n";
+  }
+
+  // ===================== RQ4: budget sweep (the knee) ========================
+  {
+    auto os = open("rq4_budget.csv");
+    os << "subject,round_limit,final_unique_nodes,peak_enodes,rounds,stop\n";
+    const char *stopName[] = {"Saturated", "RoundLimit", "NodeLimit", "Plateau",
+                              "TimeLimit"};
+    // representative sharing-heavy subjects; NestedTrie needs multiple rounds.
+    struct Pick { const char *label; std::vector<Ref> roots; };
+    Factory f1, f2, f3, f4;
+    std::vector<Pick> picks = {
+        {"RepeatedSuffix(16,8)", repeatedSuffix(f1, 16, 8)},
+        {"CrossRootReuse(12)", crossRootReuse(f2, 12)},
+        {"NestedTrie(6)", nestedTrie(f3, 6)},
+        {"NestedTrie(7)", nestedTrie(f4, 7)}};
+    const std::size_t limits[] = {1, 2, 3, 4, 5, 6, 8, 12, 32};
+    for (auto &p : picks) {
+      // raw (no EAN) left endpoint of the knee.
+      os << p.label << ",raw," << ean::computeDagStats<int>(p.roots).uniqueNodes
+         << ",-,0,NoEAN\n";
+      for (std::size_t rl : limits) {
+        Budget b = Budget::unbounded();
+        b.roundLimit = rl;
+        Factory G;
+        ean::SaturationStats st;
+        auto out = ean::ean<int>(p.roots, FULL, UNI, b, G, &st, REUSE);
+        DagStats d = ean::computeDagStats<int>(out);
+        os << p.label << "," << rl << "," << d.uniqueNodes << "," << st.peakNodes
+           << "," << st.rounds << "," << stopName[static_cast<int>(st.stop)]
+           << "\n";
+      }
+    }
+  }
+
+  // Global correctness gate: no client fact may change.
+  EXPECT_EQ(unequal, 0u);
+  EXPECT_EQ(missingRoots, 0u);
+  std::printf("[EXPORT] wrote CSVs to %s : %zu subjects, %zu comparisons, "
+              "%zu unequal, %zu missing\n",
+              outDir().c_str(), corpus.size(), comparisons, unequal,
+              missingRoots);
+}

--- a/tests/unit/Dataflow/APA/EAN/EvalRq1Test.cpp
+++ b/tests/unit/Dataflow/APA/EAN/EvalRq1Test.cpp
@@ -1,0 +1,196 @@
+// EAN evaluation — RQ1 (correctness + IR quality) on synthetic path-expression
+// families (paper Tables IV-synthetic and VI, LLVM-free).
+//
+// For each family we build a summary-root batch, run EAN, and:
+//   * assert semantic parity via the boolean-matrix Kleene oracle (which
+//     satisfies every law, so the full profile is sound) — RQ1 correctness;
+//   * report the retained-DAG reduction ratios (unique nodes, edges, concats,
+//     stars, sharing) EAN/Default — RQ1 IR quality.
+// A randomized differential over random law-profile subsets checks that EAN
+// preserves semantics under any declared profile.
+
+#include "Dataflow/APA/EAN/DagStats.h"
+#include "Dataflow/APA/EAN/EAN.h"
+
+#include "BoolKleene.h"
+
+#include <cstdio>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace lotus_test_ean;
+namespace ean = elimination::ean;
+using ean::Budget;
+using ean::CostModel;
+using ean::DagStats;
+using ean::ExtractOptions;
+using ean::LawProfile;
+using Factory = elimination::PathExprFactory<int>;
+using Ref = Factory::Ref;
+
+Ref seqOf(Factory &F, const std::vector<Ref> &xs) {
+  Ref acc = xs.front();
+  for (std::size_t i = 1; i < xs.size(); ++i) acc = F.concat(acc, xs[i]);
+  return acc;
+}
+Ref unionOf(Factory &F, const std::vector<Ref> &xs) {
+  Ref acc = xs.front();
+  for (std::size_t i = 1; i < xs.size(); ++i) acc = F.unite(acc, xs[i]);
+  return acc;
+}
+
+// ⊕_{i<k} (p0·…·p_{L-1} · c_i): k branches share an L-atom prefix.
+std::vector<Ref> repeatedPrefix(Factory &F, int k, int L) {
+  std::vector<Ref> pre;
+  for (int i = 0; i < L; ++i) pre.push_back(F.atom(i));
+  std::vector<Ref> branches;
+  for (int i = 0; i < k; ++i) {
+    std::vector<Ref> s = pre;
+    s.push_back(F.atom(100 + i));
+    branches.push_back(seqOf(F, s));
+  }
+  return {unionOf(F, branches)};
+}
+
+// ⊕_{i<k} (c_i · s0·…·s_{L-1}): k branches share an L-atom suffix.
+std::vector<Ref> repeatedSuffix(Factory &F, int k, int L) {
+  std::vector<Ref> suf;
+  for (int i = 0; i < L; ++i) suf.push_back(F.atom(i));
+  std::vector<Ref> branches;
+  for (int i = 0; i < k; ++i) {
+    std::vector<Ref> s;
+    s.push_back(F.atom(100 + i));
+    for (Ref x : suf) s.push_back(x);
+    branches.push_back(seqOf(F, s));
+  }
+  return {unionOf(F, branches)};
+}
+
+// m roots each = sharedQ · atom_j, where sharedQ is a common factorable block.
+std::vector<Ref> crossRootReuse(Factory &F, int m) {
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3);
+  Ref q = F.unite(seqOf(F, {a, b, c}), seqOf(F, {a, b, d})); // (a·b·c)⊕(a·b·d)
+  std::vector<Ref> roots;
+  for (int j = 0; j < m; ++j) roots.push_back(F.concat(q, F.atom(200 + j)));
+  return roots;
+}
+
+// (a·b)*·a  plus a nested loop — exercises sliding and star handling.
+std::vector<Ref> loopFamily(Factory &F) {
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2);
+  Ref r1 = F.concat(F.star(F.concat(a, b)), a);            // (a·b)*·a
+  Ref r2 = F.concat(F.star(F.concat(a, F.star(F.concat(b, c)))), a);
+  return {r1, r2};
+}
+
+void report(const char *name, const DagStats &d, const DagStats &e,
+            const ean::SaturationStats &s) {
+  auto ratio = [](std::size_t before, std::size_t after) {
+    return before ? static_cast<double>(after) / static_cast<double>(before) : 1.0;
+  };
+  std::printf(
+      "[RQ1] %-22s nodes %3zu->%3zu (%.2fx) edges %3zu->%3zu concat %2zu->%2zu "
+      "star %2zu->%2zu sharing %.2f->%.2f | rounds=%zu peak=%zu\n",
+      name, d.uniqueNodes, e.uniqueNodes, ratio(d.uniqueNodes, e.uniqueNodes),
+      d.uniqueEdges, e.uniqueEdges, d.concats, e.concats, d.stars, e.stars,
+      d.sharing(), e.sharing(), s.rounds, s.peakNodes);
+}
+
+// Run EAN with the full (Kleene) profile and check semantic parity + report.
+void runFamily(const char *name, const std::vector<Ref> &R) {
+  DagStats before = ean::computeDagStats<int>(R);
+  std::vector<Mat> want;
+  for (const auto &r : R) want.push_back(evalRef(r));
+
+  Factory G;
+  ean::SaturationStats stats;
+  auto out = ean::ean<int>(R, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                           Budget::unbounded(), G, &stats);
+  ASSERT_EQ(out.size(), R.size()) << name;
+  for (std::size_t i = 0; i < R.size(); ++i) {
+    EXPECT_TRUE(evalRef(out[i]) == want[i]) << name << " root " << i;
+  }
+  DagStats after = ean::computeDagStats<int>(out);
+  report(name, before, after, stats);
+  // EAN must never inflate the retained node count on these families.
+  EXPECT_LE(after.uniqueNodes, before.uniqueNodes) << name;
+}
+
+std::uint64_t g_seed = 0xE7A1;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+Ref randExpr(Factory &F, int depth) {
+  if (depth <= 0 || (rnd() % 3 == 0)) return F.atom(static_cast<int>(rnd() % 5));
+  switch (rnd() % 4) {
+  case 0: return F.unite(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 1: return F.concat(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 2: return F.star(randExpr(F, depth - 1));
+  default: return F.atom(static_cast<int>(rnd() % 5));
+  }
+}
+
+} // namespace
+
+TEST(EanEvalRq1, SyntheticFamiliesPreserveSemanticsAndReduce) {
+  { Factory F; runFamily("RepeatedPrefix(8,4)", repeatedPrefix(F, 8, 4)); }
+  { Factory F; runFamily("RepeatedSuffix(8,4)", repeatedSuffix(F, 8, 4)); }
+  { Factory F; runFamily("CrossRootReuse(6)", crossRootReuse(F, 6)); }
+  { Factory F; runFamily("LoopFamily", loopFamily(F)); }
+}
+
+// Reuse-aware extraction (K=3) vs tree extraction (K=0) on a sharing-heavy
+// batch: reuse-aware must not retain more nodes.
+TEST(EanEvalRq1, ReuseAwareVsTreeExtraction) {
+  Factory F;
+  auto R = crossRootReuse(F, 6);
+
+  Factory G0;
+  ExtractOptions tree;
+  tree.reuseIters = 0;
+  auto treeOut = ean::ean<int>(R, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                               Budget::unbounded(), G0, nullptr, tree);
+  Factory G3;
+  ExtractOptions reuse;
+  reuse.reuseIters = 3;
+  auto reuseOut = ean::ean<int>(R, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                                Budget::unbounded(), G3, nullptr, reuse);
+
+  const std::size_t treeNodes = ean::computeDagStats<int>(treeOut).uniqueNodes;
+  const std::size_t reuseNodes = ean::computeDagStats<int>(reuseOut).uniqueNodes;
+  std::printf("[RQ1] extractor tree=%zu reuse=%zu\n", treeNodes, reuseNodes);
+  EXPECT_LE(reuseNodes, treeNodes);
+}
+
+// Differential: EAN preserves semantics under randomly chosen law subsets
+// (the boolean-matrix algebra satisfies every law, so all subsets are sound).
+TEST(EanEvalRq1, RandomLawProfileDifferential) {
+  const ean::Law laws[] = {ean::Law::LeftDistributive, ean::Law::RightDistributive,
+                           ean::Law::Sliding};
+  for (int t = 0; t < 300; ++t) {
+    Factory F;
+    std::vector<Ref> R;
+    std::vector<Mat> want;
+    const int k = 1 + static_cast<int>(rnd() % 3);
+    for (int i = 0; i < k; ++i) {
+      Ref e = randExpr(F, 4);
+      R.push_back(e);
+      want.push_back(evalRef(e));
+    }
+    LawProfile L;
+    for (ean::Law law : laws)
+      if (rnd() & 1) L.enable(law);
+
+    Factory G;
+    Budget b = Budget::unbounded();
+    b.roundLimit = 200;
+    auto out = ean::ean<int>(R, L, CostModel::uniform(), b, G);
+    ASSERT_EQ(out.size(), R.size()) << "trial " << t;
+    for (std::size_t i = 0; i < R.size(); ++i)
+      EXPECT_TRUE(evalRef(out[i]) == want[i]) << "trial " << t << " root " << i;
+  }
+}

--- a/tests/unit/Dataflow/APA/EAN/EvalRq3Test.cpp
+++ b/tests/unit/Dataflow/APA/EAN/EvalRq3Test.cpp
@@ -1,0 +1,384 @@
+// EAN evaluation — RQ3 (complementarity with elimination ordering, paper §IV-D,
+// Table VI Order/Order+EAN rows). LLVM-free: synthetic CFG families run through
+// the REAL intraprocedural solver with a distributive reachability client, in
+// the 2x2 {Default, Order} x {no-EAN, EAN} configuration matrix.
+//
+// For every subject and configuration we:
+//   * assert client-fact parity vs Default (pivot order + EAN preserve results
+//     on a distributive client) — the RQ3 correctness net;
+//   * measure final retained-DAG complexity over the summary batch (Table VI);
+//   * measure peak construction nodes (Diagnostics.peak_matrix_nodes) — the
+//     ordering-only metric, plus the combinatorial peakFill proxy.
+// It then reports the Order/EAN/Order+EAN reduction rows, the Default-vs-Order
+// peak reduction per family, and the Spearman correlation between the ordering
+// gain and the EAN gain (complementarity).
+
+#include "Dataflow/APA/EAN/DagStats.h"
+#include "Dataflow/APA/Solver/EliminationOrder.h"
+#include "Dataflow/APA/Solver/Solver.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using elimination::EliminationMethod;
+using elimination::EliminationOptions;
+using elimination::IntraEliminationProblem;
+using elimination::IntraEliminationSolver;
+using elimination::OrderingPolicy;
+namespace ean = elimination::ean;
+namespace order = elimination::order;
+
+// ---- distributive reachability client (meet = set union) -------------------
+struct ReachDomain {
+  using n_t = int;
+  using fact_t = std::set<int>;
+  using transfer_t = int;
+  using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+};
+class ReachProblem final : public IntraEliminationProblem<ReachDomain> {
+public:
+  explicit ReachProblem(std::unordered_map<int, std::vector<int>> S)
+      : Succs(std::move(S)) {}
+  std::vector<int> nodes() const override {
+    std::vector<int> Ns;
+    for (auto &kv : Succs) Ns.push_back(kv.first);
+    std::sort(Ns.begin(), Ns.end());
+    return Ns;
+  }
+  int entry() const override { return 0; }
+  std::vector<int> succs(int n) const override {
+    auto it = Succs.find(n);
+    return it == Succs.end() ? std::vector<int>{} : it->second;
+  }
+  int edgeTransfer(int, int Dst) const override { return Dst; }
+  fact_t applyTransfer(const int &T, const fact_t &In) const override {
+    fact_t o = In;
+    o.insert(T);
+    return o;
+  }
+  fact_t join(const fact_t &a, const fact_t &b) const override {
+    fact_t o = a;
+    o.insert(b.begin(), b.end());
+    return o;
+  }
+  bool equal(const fact_t &a, const fact_t &b) const override { return a == b; }
+  fact_t bottom() const override { return {}; }
+  fact_t initialFact() const override { return {}; }
+
+private:
+  std::unordered_map<int, std::vector<int>> Succs;
+};
+
+using CFG = std::unordered_map<int, std::vector<int>>;
+
+// ---------------------------------------------------------------- corpus ----
+// Hub: entry 0 -> sources 1..P -> hub H -> sinks -> (dead). Ordering's主场:
+// eliminating the hub first costs P*Q; peeling leaves first costs nothing.
+CFG hub(int P, int Q) {
+  CFG S;
+  const int H = 1 + P, firstSink = H + 1;
+  S[0] = {};
+  for (int i = 1; i <= P; ++i) { S[0].push_back(i); S[i] = {H}; }
+  S[H] = {};
+  for (int j = 0; j < Q; ++j) { S[H].push_back(firstSink + j); S[firstSink + j] = {}; }
+  return S;
+}
+// Dense complete DAG: i -> j for all i < j. High predecessor-successor product.
+CFG dense(int m) {
+  CFG S;
+  for (int i = 0; i < m; ++i) {
+    S[i] = {};
+    for (int j = i + 1; j < m; ++j) S[i].push_back(j);
+  }
+  return S;
+}
+// Diamond chain: d segments, each entry_t -> {a_t,b_t} -> entry_{t+1}. Two
+// parallel branches per segment create factorable shared prefixes/suffixes.
+CFG diamondChain(int d) {
+  CFG S;
+  int next = 0;
+  int entry = next++;
+  S[entry] = {};
+  for (int t = 0; t < d; ++t) {
+    int a = next++, b = next++, join = next++;
+    S[entry] = {a, b};
+    S[a] = {join};
+    S[b] = {join};
+    S[join] = {};
+    entry = join;
+  }
+  return S;
+}
+// Nested loops: a spine 0->1->...->L with a back edge from each node to node 1
+// (nested self-similar cycles) -> star-rich summaries.
+CFG nestedLoop(int L) {
+  CFG S;
+  for (int i = 0; i <= L; ++i) S[i] = {};
+  for (int i = 0; i < L; ++i) S[i].push_back(i + 1);
+  for (int i = 2; i <= L; ++i) S[i].push_back(1); // back edges to the loop head
+  return S;
+}
+// Random reachable CFG (cycles allowed): spanning path 0->1->...->n-1 then
+// extra random forward/back edges. Deterministic PRNG.
+std::uint64_t g_seed = 0x3D3A11u;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+CFG randomCFG(int n, int extra) {
+  CFG S;
+  for (int i = 0; i < n; ++i) S[i] = {};
+  for (int i = 0; i + 1 < n; ++i) S[i].push_back(i + 1); // spanning path
+  for (int e = 0; e < extra; ++e) {
+    int a = static_cast<int>(rnd() % n), b = static_cast<int>(rnd() % n);
+    if (a == b) continue;
+    S[a].push_back(b);
+  }
+  return S;
+}
+
+struct Subject { std::string family; std::string label; CFG cfg; };
+
+void buildCorpus(std::vector<Subject> &out) {
+  for (int P : {3, 6, 10}) for (int Q : {3, 6, 10})
+    out.push_back({"Hub", "H" + std::to_string(P) + "x" + std::to_string(Q), hub(P, Q)});
+  for (int m : {5, 7, 9, 11}) out.push_back({"Dense", "D" + std::to_string(m), dense(m)});
+  for (int d : {2, 3, 4, 5}) out.push_back({"DiamondChain", "C" + std::to_string(d), diamondChain(d)});
+  for (int L : {3, 4, 5, 6}) out.push_back({"NestedLoop", "N" + std::to_string(L), nestedLoop(L)});
+  for (int t = 0; t < 12; ++t) {
+    const int n = 6 + static_cast<int>(rnd() % 8);
+    out.push_back({"Random", "R" + std::to_string(t), randomCFG(n, n)});
+  }
+}
+
+// ---------------------------------------------------------------- helpers ---
+struct GeoMean {
+  double sumLog = 0.0; std::size_t n = 0;
+  void add(double before, double after) {
+    if (before > 0.0 && after > 0.0) { sumLog += std::log(after / before); ++n; }
+  }
+  double value() const { return n ? std::exp(sumLog / static_cast<double>(n)) : 1.0; }
+};
+
+std::string outDir() {
+  const char *d = std::getenv("EAN_EVAL_OUT");
+  return d && *d ? std::string(d) : std::string(".");
+}
+std::ofstream open(const std::string &name) { return std::ofstream(outDir() + "/" + name); }
+
+EliminationOptions mkOpts(OrderingPolicy ord, bool enableEAN) {
+  EliminationOptions o;
+  o.Method = EliminationMethod::StateElimination;
+  o.Ordering = ord;
+  o.MeasurePeakNodes = true;
+  o.EnableEAN = enableEAN;
+  if (enableEAN) {
+    o.EANLaws = ean::LawProfile::kleeneAlgebra(); // reachability is distributive
+    o.EANCost = ean::CostModel::uniform();
+    o.EANExtract.reuseIters = 3;
+  }
+  return o;
+}
+
+struct RunResult {
+  ean::DagStats stats;
+  std::size_t peakNodes = 0;
+  std::map<int, std::set<int>> facts; // IN per node, for parity
+};
+RunResult run(const CFG &cfg, OrderingPolicy ord, bool enableEAN) {
+  ReachProblem P(cfg);
+  IntraEliminationSolver<ReachDomain> Solver(P, mkOpts(ord, enableEAN));
+  Solver.solve();
+  const auto &R = Solver.getResults();
+  RunResult rr;
+  std::vector<elimination::PathExprFactory<int>::Ref> batch;
+  for (int n : P.nodes()) {
+    auto E = R.ExprTo(n);
+    if (E) batch.push_back(E);
+    if (const auto *f = R.tryIN(n)) rr.facts[n] = *f;
+  }
+  rr.stats = ean::computeDagStats<int>(batch);
+  rr.peakNodes = Solver.getDiagnostics().peak_matrix_nodes;
+  return rr;
+}
+
+// Combinatorial peakFill proxy on the CFG (node ids -> sorted index).
+std::pair<std::size_t, std::size_t> peakFillProxy(const CFG &cfg) {
+  std::vector<int> ids;
+  for (auto &kv : cfg) ids.push_back(kv.first);
+  std::sort(ids.begin(), ids.end());
+  std::unordered_map<int, std::size_t> idx;
+  for (std::size_t i = 0; i < ids.size(); ++i) idx[ids[i]] = i;
+  order::EliminationGraph g(ids.size());
+  for (auto &kv : cfg)
+    for (int d : kv.second)
+      if (idx.count(d)) g.addEdge(idx[kv.first], idx[d]);
+  std::vector<std::size_t> identity(ids.size());
+  for (std::size_t i = 0; i < ids.size(); ++i) identity[i] = i;
+  const auto def = order::simulateCost(g, identity);
+  const auto ord = order::simulateCost(g, order::computeCostAwareOrder(g));
+  return {def.peakFill, ord.peakFill};
+}
+
+// Average-rank Spearman correlation.
+double spearman(const std::vector<double> &x, const std::vector<double> &y) {
+  const std::size_t n = x.size();
+  if (n < 2) return 0.0;
+  auto ranks = [n](const std::vector<double> &v) {
+    std::vector<std::size_t> idx(n);
+    for (std::size_t i = 0; i < n; ++i) idx[i] = i;
+    std::sort(idx.begin(), idx.end(), [&](std::size_t a, std::size_t b) { return v[a] < v[b]; });
+    std::vector<double> r(n);
+    for (std::size_t i = 0; i < n;) {
+      std::size_t j = i;
+      while (j < n && v[idx[j]] == v[idx[i]]) ++j;
+      const double avg = (static_cast<double>(i) + static_cast<double>(j - 1)) / 2.0 + 1.0;
+      for (std::size_t k = i; k < j; ++k) r[idx[k]] = avg;
+      i = j;
+    }
+    return r;
+  };
+  const auto rx = ranks(x), ry = ranks(y);
+  double mx = 0, my = 0;
+  for (std::size_t i = 0; i < n; ++i) { mx += rx[i]; my += ry[i]; }
+  mx /= n; my /= n;
+  double num = 0, dx = 0, dy = 0;
+  for (std::size_t i = 0; i < n; ++i) {
+    num += (rx[i] - mx) * (ry[i] - my);
+    dx += (rx[i] - mx) * (rx[i] - mx);
+    dy += (ry[i] - my) * (ry[i] - my);
+  }
+  return (dx > 0 && dy > 0) ? num / std::sqrt(dx * dy) : 0.0;
+}
+
+} // namespace
+
+TEST(EanEvalRq3, ComplementarityWithOrdering) {
+  std::vector<Subject> corpus;
+  buildCorpus(corpus);
+
+  // Table VI rows (geo-mean of config/Default ratios).
+  GeoMean gO_n, gO_e, gO_t, gO_s, gO_st;         // Order
+  GeoMean gE_n, gE_e, gE_t, gE_s, gE_st;         // EAN
+  GeoMean gOE_n, gOE_e, gOE_t, gOE_s, gOE_st;    // Order+EAN
+  double shareDef = 0, shareO = 0, shareE = 0, shareOE = 0; std::size_t shareN = 0;
+
+  // Per-family peak aggregation.
+  struct PeakAgg { std::size_t subjects = 0, defPeak = 0, ordPeak = 0, defFill = 0, ordFill = 0; };
+  std::map<std::string, PeakAgg> peak;
+  std::vector<std::string> famOrder;
+
+  // Complementarity gains + final-node geo-means.
+  std::vector<double> orderingGain, eanGain;
+  GeoMean gOrdVsDef, gEanVsDef, gOEVsDef, gOEVsOrd;
+
+  std::size_t parityChecks = 0, parityFail = 0;
+
+  for (auto &s : corpus) {
+    auto D = run(s.cfg, OrderingPolicy::Default, false);
+    auto O = run(s.cfg, OrderingPolicy::CostAware, false);
+    auto E = run(s.cfg, OrderingPolicy::Default, true);
+    auto OE = run(s.cfg, OrderingPolicy::CostAware, true);
+
+    // parity: every config must agree with Default on every node's fact.
+    for (auto &kv : D.facts) {
+      ++parityChecks;
+      if (O.facts[kv.first] != kv.second || E.facts[kv.first] != kv.second ||
+          OE.facts[kv.first] != kv.second)
+        ++parityFail;
+    }
+
+    const auto &d = D.stats;
+    auto acc = [&](const ean::DagStats &c, GeoMean &n, GeoMean &e, GeoMean &t,
+                   GeoMean &sq, GeoMean &st) {
+      n.add(d.uniqueNodes, c.uniqueNodes); e.add(d.uniqueEdges, c.uniqueEdges);
+      t.add(d.expandedTree, c.expandedTree); sq.add(d.concats, c.concats);
+      st.add(d.stars, c.stars);
+    };
+    acc(O.stats, gO_n, gO_e, gO_t, gO_s, gO_st);
+    acc(E.stats, gE_n, gE_e, gE_t, gE_s, gE_st);
+    acc(OE.stats, gOE_n, gOE_e, gOE_t, gOE_s, gOE_st);
+    shareDef += d.sharing(); shareO += O.stats.sharing();
+    shareE += E.stats.sharing(); shareOE += OE.stats.sharing(); ++shareN;
+
+    if (std::find(famOrder.begin(), famOrder.end(), s.family) == famOrder.end())
+      famOrder.push_back(s.family);
+    auto fill = peakFillProxy(s.cfg);
+    PeakAgg &pa = peak[s.family];
+    ++pa.subjects; pa.defPeak += D.peakNodes; pa.ordPeak += O.peakNodes;
+    pa.defFill += fill.first; pa.ordFill += fill.second;
+
+    orderingGain.push_back(static_cast<double>(d.uniqueNodes) - O.stats.uniqueNodes);
+    eanGain.push_back(static_cast<double>(d.uniqueNodes) - E.stats.uniqueNodes);
+    gOrdVsDef.add(d.uniqueNodes, O.stats.uniqueNodes);
+    gEanVsDef.add(d.uniqueNodes, E.stats.uniqueNodes);
+    gOEVsDef.add(d.uniqueNodes, OE.stats.uniqueNodes);
+    gOEVsOrd.add(O.stats.uniqueNodes, OE.stats.uniqueNodes);
+  }
+
+  // ---- Table VI Order/EAN/Order+EAN rows ----
+  {
+    auto os = open("table6_order_rows.csv");
+    os << "configuration,unique_nodes,dag_edges,tree_size,sequence,stars,"
+          "sharing_before,sharing_after\n";
+    auto row = [&](const char *name, GeoMean &n, GeoMean &e, GeoMean &t,
+                   GeoMean &sq, GeoMean &st, double shareAfter) {
+      os << name << "," << n.value() << "," << e.value() << "," << t.value()
+         << "," << sq.value() << "," << st.value() << ","
+         << (shareN ? shareDef / shareN : 0.0) << ","
+         << (shareN ? shareAfter / shareN : 0.0) << "\n";
+    };
+    row("Order", gO_n, gO_e, gO_t, gO_s, gO_st, shareO);
+    row("EAN", gE_n, gE_e, gE_t, gE_s, gE_st, shareE);
+    row("Order+EAN", gOE_n, gOE_e, gOE_t, gOE_s, gOE_st, shareOE);
+  }
+
+  // ---- RQ3 peak (Default vs Order) ----
+  {
+    auto os = open("rq3_peak.csv");
+    os << "family,subjects,default_peak_nodes,order_peak_nodes,peak_ratio,"
+          "default_peakfill,order_peakfill\n";
+    for (const auto &f : famOrder) {
+      const PeakAgg &a = peak[f];
+      const double dn = static_cast<double>(a.defPeak) / a.subjects;
+      const double on = static_cast<double>(a.ordPeak) / a.subjects;
+      os << f << "," << a.subjects << "," << dn << "," << on << ","
+         << (dn > 0 ? on / dn : 1.0) << ","
+         << static_cast<double>(a.defFill) / a.subjects << ","
+         << static_cast<double>(a.ordFill) / a.subjects << "\n";
+    }
+  }
+
+  // ---- RQ3 complementarity ----
+  {
+    auto os = open("rq3_complementarity.csv");
+    os << "metric,value\n";
+    os << "n_subjects," << corpus.size() << "\n";
+    os << "spearman_ordering_vs_ean_gain," << spearman(orderingGain, eanGain) << "\n";
+    os << "order_vs_default_final," << gOrdVsDef.value() << "\n";
+    os << "ean_vs_default_final," << gEanVsDef.value() << "\n";
+    os << "orderEAN_vs_default_final," << gOEVsDef.value() << "\n";
+    os << "orderEAN_vs_order_final," << gOEVsOrd.value() << "\n";
+    os << "parity_checks," << parityChecks << "\n";
+    os << "parity_failures," << parityFail << "\n";
+  }
+
+  EXPECT_EQ(parityFail, 0u);
+  std::printf("[RQ3] %zu subjects, parity %zu/%zu ok, Order/Def=%.3f EAN/Def=%.3f "
+              "Order+EAN/Def=%.3f rho=%.3f\n",
+              corpus.size(), parityChecks - parityFail, parityChecks,
+              gOrdVsDef.value(), gEanVsDef.value(), gOEVsDef.value(),
+              spearman(orderingGain, eanGain));
+}

--- a/tests/unit/Dataflow/APA/EAN/ExpandTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/ExpandTest.cpp
@@ -1,0 +1,97 @@
+// EAN step-3 tests: guarded expansion (Explore phase) and the unscheduled
+// saturation mode. Expansion must (a) fire only when it aligns with structure
+// already in the e-graph, (b) preserve client semantics, and (c) leave results
+// unchanged under both the scheduled and unscheduled drivers.
+
+#include "Dataflow/APA/EAN/Canonical.h"
+#include "Dataflow/APA/EAN/EAN.h"
+#include "Dataflow/APA/EAN/Expand.h"
+#include "Dataflow/APA/EAN/Export.h"
+#include "Dataflow/APA/EAN/Import.h"
+
+#include "BoolKleene.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace lotus_test_ean;
+namespace ean = elimination::ean;
+using ean::CostModel;
+using ean::ExtractOptions;
+using ean::LawProfile;
+using Factory = elimination::PathExprFactory<int>;
+using Ref = Factory::Ref;
+
+// Expansion fires when a produced branch (a·c) already exists as a shared class.
+TEST(EanExpand, FiresOnAlignedSharing) {
+  Factory F;
+  Ref a = F.atom(0), c = F.atom(1), d = F.atom(2);
+  Ref r1 = F.concat(a, F.unite(c, d)); // a·(c⊕d)
+  Ref r2 = F.concat(a, c);             // a·c  — the aligned product
+  auto imp = ean::importCanonical<int>({r1, r2});
+
+  ExtractOptions opts; // expandMinAligned = 1
+  const std::size_t ch =
+      ean::expandRound(imp.g, LawProfile::kleeneAlgebra(), opts);
+  EXPECT_GT(ch, 0u) << "expansion should fire when a·c already exists";
+}
+
+// Expansion is rejected when no produced branch aligns with existing structure.
+TEST(EanExpand, RejectsUnalignedExpansion) {
+  Factory F;
+  Ref a = F.atom(0), c = F.atom(1), d = F.atom(2);
+  Ref r1 = F.concat(a, F.unite(c, d)); // a·(c⊕d); a·c / a·d exist nowhere else
+  auto imp = ean::importCanonical<int>({r1});
+
+  ExtractOptions opts; // expandMinAligned = 1
+  const std::size_t ch =
+      ean::expandRound(imp.g, LawProfile::kleeneAlgebra(), opts);
+  EXPECT_EQ(ch, 0u) << "no aligned branch → expansion must be rejected";
+}
+
+// Disabling the alignment requirement (min=0) admits the expansion.
+TEST(EanExpand, MinAlignedZeroAdmits) {
+  Factory F;
+  Ref a = F.atom(0), c = F.atom(1), d = F.atom(2);
+  Ref r1 = F.concat(a, F.unite(c, d));
+  auto imp = ean::importCanonical<int>({r1});
+
+  ExtractOptions opts;
+  opts.expandMinAligned = 0;
+  const std::size_t ch =
+      ean::expandRound(imp.g, LawProfile::kleeneAlgebra(), opts);
+  EXPECT_GT(ch, 0u) << "min-aligned 0 removes the alignment guard";
+}
+
+// End-to-end ean() preserves client facts with the Explore phase active, in both
+// the scheduled and unscheduled drivers.
+TEST(EanExpand, PreservesSemanticsScheduledAndUnscheduled) {
+  Factory F;
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3);
+  Ref r1 = F.concat(a, F.unite(c, d));                    // a·(c⊕d)
+  Ref r2 = F.concat(a, c);                                // a·c
+  Ref r3 = F.unite(F.concat(a, c), F.concat(b, c));       // a·c ⊕ b·c
+  std::vector<Ref> R = {r1, r2, r3};
+  std::vector<Mat> before;
+  for (const auto &r : R) {
+    before.push_back(evalRef(r));
+  }
+
+  for (bool scheduled : {true, false}) {
+    ExtractOptions opts;
+    opts.scheduled = scheduled;
+    Factory G;
+    auto out = ean::ean<int>(R, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                             ean::Budget::unbounded(), G, nullptr, opts);
+    ASSERT_EQ(out.size(), R.size()) << "scheduled=" << scheduled;
+    for (std::size_t i = 0; i < R.size(); ++i) {
+      EXPECT_TRUE(evalRef(out[i]) == before[i])
+          << "scheduled=" << scheduled << " root " << i;
+    }
+  }
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/EAN/FactorizeTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/FactorizeTest.cpp
@@ -1,0 +1,195 @@
+// EAN M2 factorization tests.
+//
+// Correctness is checked two ways:
+//  1. Differential: import -> factorize -> export, and the boolean-matrix
+//     Kleene interpretation is unchanged from the original expression.
+//  2. E-graph consistency: EVERY e-node in EVERY class evaluates to the same
+//     matrix as its class representative — i.e. factorization never united a
+//     semantically-different node into a class. This directly validates the
+//     factored e-nodes, not just whichever one export happens to pick.
+// Plus structural checks (a factored form actually appeared) and law gating.
+
+#include "Dataflow/APA/EAN/Export.h"
+#include "Dataflow/APA/EAN/Factorize.h"
+#include "Dataflow/APA/EAN/Import.h"
+
+#include "BoolKleene.h"
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace lotus_test_ean;
+namespace ean = elimination::ean;
+using ean::Graph;
+using ean::Id;
+using ean::LawProfile;
+using ean::Law;
+using ean::PathLang;
+using Factory = elimination::PathExprFactory<int>;
+using Ref = Factory::Ref;
+
+// ---- graph-side evaluator (front representative) + consistency check --------
+
+Mat evalClass(Graph &g, const ean::AtomTable<int> &atoms, Id c,
+              std::unordered_map<std::uint32_t, Mat> &memo);
+
+Mat evalNode(Graph &g, const ean::AtomTable<int> &atoms, const PathLang &n,
+             std::unordered_map<std::uint32_t, Mat> &memo) {
+  if (ean::isZero(n)) return zeroM();
+  if (ean::isOne(n)) return oneM();
+  if (ean::isAtom(n)) return gen(*atoms.atom(ean::parseAtomId(n))->Transfer);
+  if (ean::isStar(n)) return closureM(evalClass(g, atoms, n.children()[0], memo));
+  if (ean::isJoin(n)) {
+    Mat m = zeroM();
+    for (Id ch : n.children()) m = orM(m, evalClass(g, atoms, ch, memo));
+    return m;
+  }
+  // seq
+  Mat m = oneM();
+  for (Id ch : n.children()) m = mulM(m, evalClass(g, atoms, ch, memo));
+  return m;
+}
+
+Mat evalClass(Graph &g, const ean::AtomTable<int> &atoms, Id c,
+              std::unordered_map<std::uint32_t, Mat> &memo) {
+  c = g.find(c);
+  auto it = memo.find(c.value());
+  if (it != memo.end()) return it->second;
+  Mat m = evalNode(g, atoms, g[c].nodes.front(), memo);
+  memo[c.value()] = m;
+  return m;
+}
+
+// Every e-node in every class must equal its class representative.
+bool allClassesConsistent(Graph &g, const ean::AtomTable<int> &atoms) {
+  std::unordered_map<std::uint32_t, Mat> memo;
+  for (Id c : g.classIds()) {
+    c = g.find(c);
+    (void)evalClass(g, atoms, c, memo); // representative value
+  }
+  for (Id c : g.classIds()) {
+    c = g.find(c);
+    const Mat ref = memo[c.value()];
+    for (const PathLang &n : g[c].nodes) {
+      if (evalNode(g, atoms, n, memo) != ref) return false;
+    }
+  }
+  return true;
+}
+
+// deterministic LCG for reproducible random expressions
+std::uint64_t g_seed = 0xC0FFEE;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+Ref randExpr(Factory &F, int depth) {
+  if (depth <= 0 || (rnd() % 3 == 0)) return F.atom(static_cast<int>(rnd() % 5));
+  switch (rnd() % 4) {
+  case 0: return F.unite(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 1: return F.concat(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 2: return F.star(randExpr(F, depth - 1));
+  default: return F.atom(static_cast<int>(rnd() % 5));
+  }
+}
+
+Ref seq3(Factory &F, Ref x, Ref y, Ref z) {
+  return F.concat(F.concat(x, y), z);
+}
+
+} // namespace
+
+// (a·b·c) ⊕ (a·b·d)  →  a·b·(c⊕d) added; semantics preserved.
+TEST(EanFactorize, PrefixFactorAppearsAndPreservesSemantics) {
+  Factory F;
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3);
+  Ref r = F.unite(seq3(F, a, b, c), seq3(F, a, b, d));
+  const Mat before = evalRef(r);
+
+  auto imp = ean::importCanonical<int>({r});
+  ASSERT_EQ(imp.g[imp.roots[0]].nodes.size(), 1u); // one JOIN node after import
+  ean::factorizeToFixpoint(imp.g, LawProfile::kleeneAlgebra());
+
+  EXPECT_GE(imp.g[imp.roots[0]].nodes.size(), 2u) << "no factored form added";
+  EXPECT_TRUE(allClassesConsistent(imp.g, imp.atoms));
+
+  Factory G;
+  auto out = ean::exportBatch<int>(imp, G);
+  EXPECT_TRUE(evalRef(out[0]) == before);
+}
+
+// Partial grouping: (a·b·c) ⊕ (a·b·d) ⊕ x  →  (a·b·(c⊕d)) ⊕ x.
+TEST(EanFactorize, PartialGroupingKeepsNonParticipant) {
+  Factory F;
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3), x = F.atom(4);
+  Ref r = F.unite(F.unite(seq3(F, a, b, c), seq3(F, a, b, d)), x);
+  const Mat before = evalRef(r);
+
+  auto imp = ean::importCanonical<int>({r});
+  ean::factorizeToFixpoint(imp.g, LawProfile::kleeneAlgebra());
+
+  EXPECT_GE(imp.g[imp.roots[0]].nodes.size(), 2u);
+  EXPECT_TRUE(allClassesConsistent(imp.g, imp.atoms));
+  Factory G;
+  auto out = ean::exportBatch<int>(imp, G);
+  EXPECT_TRUE(evalRef(out[0]) == before);
+}
+
+// Suffix: (c·a) ⊕ (d·a)  →  (c⊕d)·a.
+TEST(EanFactorize, SuffixFactorPreservesSemantics) {
+  Factory F;
+  Ref a = F.atom(0), c = F.atom(2), d = F.atom(3);
+  Ref r = F.unite(F.concat(c, a), F.concat(d, a));
+  const Mat before = evalRef(r);
+
+  auto imp = ean::importCanonical<int>({r});
+  ean::factorizeToFixpoint(imp.g, LawProfile::kleeneAlgebra());
+
+  EXPECT_GE(imp.g[imp.roots[0]].nodes.size(), 2u);
+  EXPECT_TRUE(allClassesConsistent(imp.g, imp.atoms));
+  Factory G;
+  auto out = ean::exportBatch<int>(imp, G);
+  EXPECT_TRUE(evalRef(out[0]) == before);
+}
+
+// Disabling LeftDistributive suppresses prefix factorization.
+TEST(EanFactorize, LawProfileGatesPrefix) {
+  Factory F;
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3);
+  Ref r = F.unite(seq3(F, a, b, c), seq3(F, a, b, d)); // only a prefix factor exists
+
+  auto imp = ean::importCanonical<int>({r});
+  // Right only: no common suffix (c != d) -> nothing fires.
+  LawProfile rightOnly;
+  rightOnly.enable(Law::RightDistributive);
+  EXPECT_EQ(ean::factorizeRound(imp.g, rightOnly), 0u);
+  EXPECT_EQ(imp.g[imp.roots[0]].nodes.size(), 1u);
+
+  // Enable left -> prefix factor now appears.
+  LawProfile leftOnly;
+  leftOnly.enable(Law::LeftDistributive);
+  EXPECT_GT(ean::factorizeRound(imp.g, leftOnly), 0u);
+  EXPECT_GE(imp.g[imp.roots[0]].nodes.size(), 2u);
+}
+
+// Factorization never changes the interpretation, on random expressions.
+TEST(EanFactorize, RandomizedDifferential) {
+  for (int t = 0; t < 500; ++t) {
+    Factory F;
+    Ref e = randExpr(F, 4);
+    const Mat before = evalRef(e);
+
+    auto imp = ean::importCanonical<int>({e});
+    ean::factorizeToFixpoint(imp.g, LawProfile::kleeneAlgebra());
+
+    EXPECT_TRUE(allClassesConsistent(imp.g, imp.atoms)) << "trial " << t;
+    Factory G;
+    auto out = ean::exportBatch<int>(imp, G);
+    EXPECT_TRUE(evalRef(out[0]) == before) << "trial " << t;
+  }
+}

--- a/tests/unit/Dataflow/APA/EAN/GreedyTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/GreedyTest.cpp
@@ -1,0 +1,110 @@
+// Greedy one-pass simplifier tests (paper's "Greedy" configuration).
+//
+// greedySimplify applies deterministic prefix factorization on the factory DAG.
+// We check (a) it preserves semantics under the boolean-matrix Kleene oracle
+// (prefix factorization = left distributivity, universally sound), and (b) it
+// actually reduces the retained DAG on shared-prefix batches.
+
+#include "Dataflow/APA/EAN/DagStats.h"
+#include "Dataflow/APA/EAN/Greedy.h"
+
+#include "BoolKleene.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace lotus_test_ean;
+using Factory = elimination::PathExprFactory<int>;
+using Ref = Factory::Ref;
+
+Ref seqOf(Factory &F, const std::vector<Ref> &xs) {
+  Ref acc = xs.front();
+  for (std::size_t i = 1; i < xs.size(); ++i) acc = F.concat(acc, xs[i]);
+  return acc;
+}
+
+std::size_t nodes(const std::vector<Ref> &R) {
+  return elimination::ean::computeDagStats<int>(R).uniqueNodes;
+}
+
+// (a·b·c) ⊕ (a·b·d): shared prefix a·b must be factored out.
+TEST(Greedy, FactorsSharedPrefixAndPreservesSemantics) {
+  Factory F;
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3);
+  std::vector<Ref> R = {F.unite(seqOf(F, {a, b, c}), seqOf(F, {a, b, d}))};
+  const Mat want = evalRef(R[0]);
+
+  auto out = elimination::greedySimplify<int>(R, F);
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_TRUE(evalRef(out[0]) == want);          // semantics preserved
+  EXPECT_LT(nodes(out), nodes(R));               // strictly smaller DAG
+}
+
+// Cross-root shared prefix: two roots sharing a·b, factored per root, and the
+// factory hash-conses the shared factor across roots.
+TEST(Greedy, CrossRootSharingPreserved) {
+  Factory F;
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3), e = F.atom(4);
+  std::vector<Ref> R = {
+      F.unite(seqOf(F, {a, b, c}), seqOf(F, {a, b, d})),
+      F.unite(seqOf(F, {a, b, d}), seqOf(F, {a, b, e}))};
+  std::vector<Mat> want = {evalRef(R[0]), evalRef(R[1])};
+
+  auto out = elimination::greedySimplify<int>(R, F);
+  ASSERT_EQ(out.size(), 2u);
+  for (std::size_t i = 0; i < 2; ++i)
+    EXPECT_TRUE(evalRef(out[i]) == want[i]) << "root " << i;
+  EXPECT_LE(nodes(out), nodes(R));
+}
+
+// Idempotent: greedySimplify of an already-simplified batch is a fixpoint.
+TEST(Greedy, Idempotent) {
+  Factory F;
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2);
+  std::vector<Ref> R = {F.unite(seqOf(F, {a, b}), seqOf(F, {a, c}))};
+  auto o1 = elimination::greedySimplify<int>(R, F);
+  auto o2 = elimination::greedySimplify<int>(o1, F);
+  ASSERT_EQ(o1.size(), o2.size());
+  EXPECT_EQ(nodes(o1), nodes(o2));
+  EXPECT_TRUE(evalRef(o1[0]) == evalRef(o2[0]));
+}
+
+// Randomized differential: greedySimplify never changes the interpretation.
+std::uint64_t g_seed = 0x51EED;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+Ref randExpr(Factory &F, int depth) {
+  if (depth <= 0 || (rnd() % 3 == 0)) return F.atom(static_cast<int>(rnd() % 5));
+  switch (rnd() % 4) {
+  case 0: return F.unite(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 1: return F.concat(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 2: return F.star(randExpr(F, depth - 1));
+  default: return F.atom(static_cast<int>(rnd() % 5));
+  }
+}
+
+TEST(Greedy, RandomizedDifferential) {
+  for (int t = 0; t < 500; ++t) {
+    Factory F;
+    std::vector<Ref> R;
+    std::vector<Mat> want;
+    const int k = 1 + static_cast<int>(rnd() % 3);
+    for (int i = 0; i < k; ++i) {
+      Ref e = randExpr(F, 5);
+      R.push_back(e);
+      want.push_back(evalRef(e));
+    }
+    auto out = elimination::greedySimplify<int>(R, F);
+    ASSERT_EQ(out.size(), R.size()) << "trial " << t;
+    for (std::size_t i = 0; i < R.size(); ++i)
+      EXPECT_TRUE(evalRef(out[i]) == want[i]) << "trial " << t << " root " << i;
+    EXPECT_LE(nodes(out), nodes(R)) << "trial " << t;
+  }
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/EAN/InterWiringTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/InterWiringTest.cpp
@@ -1,0 +1,286 @@
+// Interprocedural EAN/Greedy wiring tests (M6b).
+//
+// ForwardInterSummarySolver builds one path-expression summary per
+// (instruction, call-string context) and interprets it into a client fact.
+// EAN/Greedy post-optimize that summary batch before interpretation. These
+// tests assert:
+//   (a) the optimized forms produce IDENTICAL IN/OUT facts (RQ1-inter:
+//       safe-minimal EAN/Greedy are semantics-preserving for every client);
+//   (b) they never enlarge the retained DAG, and strictly shrink it on a batch
+//       with a shared prefix (Table VI-inter).
+//
+// The summary interpreter composes atoms as Concat = sequential apply and
+// Union = merge, so left distributivity (a·b)⊕(a·c) = a·(b⊕c) holds
+// unconditionally — the same structural argument as the intraprocedural case —
+// regardless of atom kind. A join-closed set-domain client is used so Star
+// iterations converge and the distributive-shaped algebra is exercised.
+
+#include "Dataflow/APA/Core/InterProblem.h"
+#include "Dataflow/APA/Core/InterResult.h"
+#include "Dataflow/APA/Core/Options.h"
+#include "Dataflow/APA/EAN/DagStats.h"
+#include "Dataflow/APA/Solver/ForwardInterSummarySolver.h"
+
+#include <cstdint>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using dataflow::controlflow::FlowDirection;
+
+// A minimal fake interprocedural CFG over integer node ids. Purely
+// intraprocedural edges (no call sites) suffice to exercise the summary
+// path-expression batch: EAN treats every atom as opaque, so atom KIND is
+// irrelevant to the factorization being validated.
+struct FakeICF {
+  std::unordered_map<int, std::vector<int>> Succ; // forward successors
+  std::vector<int> Starts;                         // entry instruction(s)
+
+  bool isCallSite(int) const { return false; }
+  std::vector<int> getCalleesOfCallAt(int) const { return {}; }
+  std::vector<int> getStartPointsOf(int) const { return Starts; }
+  std::vector<int> getExitPointsOf(int) const { return {}; }
+  std::vector<int> getReturnSitesOfCallAt(int) const { return {}; }
+  std::vector<int> getSuccsOf(int Inst, FlowDirection) const {
+    auto It = Succ.find(Inst);
+    return It == Succ.end() ? std::vector<int>{} : It->second;
+  }
+};
+
+struct FakeDomain {
+  using n_t = int;
+  using fact_t = std::uint64_t; // small bitset lattice
+  using transfer_t = int;       // transfer == source node (default edgeTransfer)
+  using f_t = int;
+  using i_t = FakeICF;
+  using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+};
+
+// normalFlow(node, in) = in | bit(node); merge = OR. A monotone, join-closed
+// set domain: Star iterations converge, and Union/Concat exercise the
+// distributive-shaped algebra the factorization relies on.
+class FakeProblem : public elimination::InterEliminationProblem<FakeDomain> {
+public:
+  FakeProblem(const FakeICF *ICF, int Entry)
+      : elimination::InterEliminationProblem<FakeDomain>({Entry}, ICF),
+        EntryInst(Entry) {}
+
+  static std::uint64_t bit(int Node) {
+    return std::uint64_t{1} << (static_cast<unsigned>(Node) % 63u);
+  }
+
+  fact_t normalFlow(n_t Inst, const fact_t &In) override {
+    return In | bit(Inst);
+  }
+  fact_t join(const fact_t &A, const fact_t &B) const override { return A | B; }
+  bool equal(const fact_t &A, const fact_t &B) const override {
+    return A == B;
+  }
+  fact_t bottom() const override { return 0; }
+
+  fact_t callFlow(n_t, f_t, const fact_t &In) override { return In; }
+  fact_t returnFlow(n_t, f_t, n_t, n_t, const fact_t &In) override { return In; }
+  fact_t callToRetFlow(n_t, n_t, const std::vector<f_t> &,
+                       const fact_t &In) override {
+    return In;
+  }
+  std::unordered_map<n_t, fact_t> initialSeeds() override {
+    return {{EntryInst, bit(EntryInst)}};
+  }
+  std::vector<f_t> getCalleesOfCallAt(n_t) const override { return {}; }
+
+private:
+  int EntryInst;
+};
+
+constexpr unsigned kK = 2;
+using SolverTy = elimination::ForwardInterSummarySolver<FakeDomain, kK>;
+
+struct SolveOut {
+  std::map<int, std::uint64_t> In;
+  std::map<int, std::uint64_t> Out;
+  elimination::InterSummarySolveDiagnostics Diag;
+};
+
+// Run the solver over `Icf` with the given post-pass options and collect
+// IN/OUT facts keyed by instruction id (contexts are empty for the pure
+// intraprocedural fake, so there is exactly one key per node).
+SolveOut runSolve(const FakeICF &Icf, int Entry, const std::vector<int> &Nodes,
+                  const elimination::InterEANOptions &EanOpts) {
+  FakeProblem Problem(&Icf, Entry);
+  elimination::PathSummaryEquationOptions Opts;
+  Opts.EAN = EanOpts;
+  SolverTy Solver(Problem, Opts);
+  Solver.solve();
+
+  SolveOut Out;
+  Out.Diag = Solver.resultDiagnostics();
+  const auto *Res = Solver.getResults();
+  EXPECT_NE(Res, nullptr);
+  if (Res == nullptr) {
+    return Out;
+  }
+  for (int N : Nodes) {
+    const auto Keys = Res->contextsForInstruction(N);
+    for (const auto &Key : Keys) {
+      if (const auto *InFact = Res->tryIN(Key)) {
+        Out.In[N] = *InFact;
+      }
+      if (const auto *OutFact = Res->tryOUT(Key)) {
+        Out.Out[N] = *OutFact;
+      }
+    }
+  }
+  return Out;
+}
+
+elimination::InterEANOptions defaultOpts() { return {}; }
+
+elimination::InterEANOptions eanOpts() {
+  elimination::InterEANOptions O;
+  O.EnableEAN = true;
+  O.EANMonotone = true; // never enlarge the batch (Table VI-inter guarantee)
+  return O;
+}
+
+elimination::InterEANOptions greedyOpts() {
+  elimination::InterEANOptions O;
+  O.EnableGreedy = true;
+  return O;
+}
+
+// entry 1 fans out 3-way to {2,3,4} (shared prefix), merges at 5 with a
+// self-loop (Star), then exits at 6. Exercises Union, Concat, Star, and a
+// factorable shared prefix in one graph.
+FakeICF fanLoopCfg() {
+  FakeICF Icf;
+  Icf.Starts = {1};
+  Icf.Succ[1] = {2, 3, 4};
+  Icf.Succ[2] = {5};
+  Icf.Succ[3] = {5};
+  Icf.Succ[4] = {5};
+  Icf.Succ[5] = {5, 6}; // self-loop + exit
+  return Icf;
+}
+const std::vector<int> fanLoopNodes = {1, 2, 3, 4, 5, 6};
+
+TEST(InterEAN, EANPreservesSemantics) {
+  const FakeICF Icf = fanLoopCfg();
+  const auto Base = runSolve(Icf, 1, fanLoopNodes, defaultOpts());
+  const auto Ean = runSolve(Icf, 1, fanLoopNodes, eanOpts());
+  EXPECT_EQ(Base.In, Ean.In);
+  EXPECT_EQ(Base.Out, Ean.Out);
+}
+
+TEST(InterEAN, GreedyPreservesSemantics) {
+  const FakeICF Icf = fanLoopCfg();
+  const auto Base = runSolve(Icf, 1, fanLoopNodes, defaultOpts());
+  const auto Greedy = runSolve(Icf, 1, fanLoopNodes, greedyOpts());
+  EXPECT_EQ(Base.In, Greedy.In);
+  EXPECT_EQ(Base.Out, Greedy.Out);
+}
+
+// The monotone guard must ensure the retained summary DAG never grows, on
+// either the EAN or the Greedy post-pass. (Whether it STRICTLY shrinks depends
+// on the batch: on small solver outputs EAN's re-binarized canonical form is
+// often no smaller than the solver's native factoring, and the guard then
+// returns the input verbatim — an honest, batch-dependent outcome. Strict
+// reduction on the inter atom algebra is validated deterministically below in
+// EANFactorsInterAtomBatch, and empirically on the corpus.)
+TEST(InterEAN, NeverEnlargesBatch) {
+  const FakeICF Icf = fanLoopCfg();
+  const auto Ean = runSolve(Icf, 1, fanLoopNodes, eanOpts());
+  ASSERT_GT(Ean.Diag.summary_before.uniqueNodes, 0u);
+  EXPECT_LE(Ean.Diag.summary_after.uniqueNodes,
+            Ean.Diag.summary_before.uniqueNodes);
+
+  const auto Greedy = runSolve(Icf, 1, fanLoopNodes, greedyOpts());
+  EXPECT_LE(Greedy.Diag.summary_after.uniqueNodes,
+            Greedy.Diag.summary_before.uniqueNodes);
+}
+
+// Deterministic proof that EAN reduces a batch over the interprocedural atom
+// algebra: (a·b) ⊕ (a·c) has a shared prefix `a` that left distributivity
+// factors to a·(b⊕c), removing one concat node. Run unguarded so the guard
+// cannot mask the reduction. This also exercises ean<atom_t> — the generic
+// instantiation over the opaque inter transfer atom.
+TEST(InterEAN, EANFactorsInterAtomBatch) {
+  using Atom = elimination::InterSummaryTransferAtom<FakeDomain>;
+  using Factory = elimination::PathExprFactory<Atom>;
+  Factory F;
+  const auto A = F.atom(Atom::rawNormal(1));
+  const auto B = F.atom(Atom::rawNormal(2));
+  const auto C = F.atom(Atom::rawNormal(3));
+  std::vector<Factory::Ref> R = {F.unite(F.concat(A, B), F.concat(A, C))};
+
+  const auto Before = elimination::ean::computeDagStats<Atom>(R).uniqueNodes;
+  elimination::ean::ExtractOptions EO; // monotoneGuard = false
+  const auto Out = elimination::ean::ean<Atom>(
+      R, elimination::ean::LawProfile::safeMinimal(),
+      elimination::ean::CostModel::uniform(),
+      elimination::ean::Budget::unbounded(), F, nullptr, EO);
+  ASSERT_EQ(Out.size(), 1u);
+  const auto After = elimination::ean::computeDagStats<Atom>(Out).uniqueNodes;
+  EXPECT_LT(After, Before) << "left-distributive prefix factoring should shrink";
+}
+
+// The default (no post-pass) path records the batch size but leaves it
+// unchanged and adds no normalization cost.
+TEST(InterEAN, DefaultIsNoOp) {
+  const FakeICF Icf = fanLoopCfg();
+  const auto Base = runSolve(Icf, 1, fanLoopNodes, defaultOpts());
+  EXPECT_EQ(Base.Diag.summary_after.uniqueNodes,
+            Base.Diag.summary_before.uniqueNodes);
+  EXPECT_EQ(Base.Diag.norm_time_us, 0u);
+}
+
+// Randomized differential: on many random rooted DAGs (optionally with
+// self-loops), EAN must never change any client fact.
+std::uint64_t g_seed = 0xEA9;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+
+TEST(InterEAN, RandomizedDifferential) {
+  for (int Trial = 0; Trial < 300; ++Trial) {
+    const int N = 5 + static_cast<int>(rnd() % 6); // 5..10 nodes
+    FakeICF Icf;
+    Icf.Starts = {1};
+    std::vector<int> Nodes;
+    Nodes.reserve(N);
+    for (int I = 1; I <= N; ++I) {
+      Nodes.push_back(I);
+    }
+    // Each node i>1 gets 1-2 forward preds from {1..i-1}: rooted, reachable,
+    // acyclic before optional self-loops.
+    for (int I = 2; I <= N; ++I) {
+      const int P1 = 1 + static_cast<int>(rnd() % static_cast<unsigned>(I - 1));
+      Icf.Succ[P1].push_back(I);
+      if (rnd() % 2 == 0) {
+        const int P2 =
+            1 + static_cast<int>(rnd() % static_cast<unsigned>(I - 1));
+        if (P2 != P1) {
+          Icf.Succ[P2].push_back(I);
+        }
+      }
+      if (rnd() % 4 == 0) {
+        Icf.Succ[I].push_back(I); // self-loop -> Star
+      }
+    }
+
+    const auto Base = runSolve(Icf, 1, Nodes, defaultOpts());
+    const auto Ean = runSolve(Icf, 1, Nodes, eanOpts());
+    EXPECT_EQ(Base.In, Ean.In) << "trial " << Trial;
+    EXPECT_EQ(Base.Out, Ean.Out) << "trial " << Trial;
+    EXPECT_LE(Ean.Diag.summary_after.uniqueNodes,
+              Ean.Diag.summary_before.uniqueNodes)
+        << "trial " << Trial;
+  }
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/EAN/RoundtripTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/RoundtripTest.cpp
@@ -1,0 +1,146 @@
+// EAN M1 roundtrip test: importCanonical -> exportBatch must preserve
+// semantics under an arbitrary Kleene-algebra interpretation, and must
+// canonicalize choice into ACI form.
+//
+// The differential interpreter is a boolean 3x3 matrix Kleene algebra
+// (join = OR, seq = boolean matmul, star = reflexive-transitive closure,
+// zero = zero matrix, one = identity). Atoms (ints) map deterministically to
+// generator matrices. Equality of the interpretation before/after roundtrip
+// witnesses semantic preservation; this doubles as the seed of the RQ1
+// differential-testing harness.
+
+#include "Dataflow/APA/EAN/Export.h"
+#include "Dataflow/APA/EAN/Import.h"
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using elimination::PathExprFactory;
+namespace ean = elimination::ean;
+
+constexpr int N = 3;
+struct Mat {
+  std::array<std::array<bool, N>, N> a{};
+  bool operator==(const Mat &o) const { return a == o.a; }
+};
+Mat zeroM() { return Mat{}; }
+Mat oneM() {
+  Mat m;
+  for (int i = 0; i < N; ++i) m.a[i][i] = true;
+  return m;
+}
+Mat orM(const Mat &x, const Mat &y) {
+  Mat r;
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j) r.a[i][j] = x.a[i][j] || y.a[i][j];
+  return r;
+}
+Mat mulM(const Mat &x, const Mat &y) {
+  Mat r;
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j) {
+      bool s = false;
+      for (int k = 0; k < N; ++k) s = s || (x.a[i][k] && y.a[k][j]);
+      r.a[i][j] = s;
+    }
+  return r;
+}
+Mat closureM(const Mat &x) {
+  Mat r = oneM(), p = oneM();
+  for (int it = 0; it < N + 1; ++it) {
+    p = mulM(p, x);
+    r = orM(r, p);
+  }
+  return r;
+}
+Mat gen(int id) {
+  Mat m;
+  std::uint32_t h = static_cast<std::uint32_t>(id) * 2654435761u + 0x9e3779b9u;
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j) m.a[i][j] = ((h >> (i * N + j)) & 1u) != 0;
+  return m;
+}
+
+using Ref = PathExprFactory<int>::Ref;
+using Kind = PathExprFactory<int>::Kind;
+Mat eval(const Ref &e) {
+  switch (e->K) {
+  case Kind::Zero: return zeroM();
+  case Kind::One: return oneM();
+  case Kind::Atom: return gen(*e->Transfer);
+  case Kind::Union: return orM(eval(e->L), eval(e->R));
+  case Kind::Concat: return mulM(eval(e->L), eval(e->R));
+  case Kind::Star: return closureM(eval(e->L));
+  }
+  return zeroM();
+}
+
+// deterministic LCG for reproducible randomized expressions
+std::uint64_t g_seed = 0x1234567;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+Ref randExpr(PathExprFactory<int> &F, int depth) {
+  if (depth <= 0 || (rnd() % 3 == 0)) return F.atom(static_cast<int>(rnd() % 4));
+  switch (rnd() % 4) {
+  case 0: return F.unite(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 1: return F.concat(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 2: return F.star(randExpr(F, depth - 1));
+  default: return F.atom(static_cast<int>(rnd() % 4));
+  }
+}
+
+} // namespace
+
+// Paper Eq.2 batch: r1 = (p·c)⊕(p·d), r2 = p·c, with p = a⊕b.
+TEST(EanRoundtrip, PaperExampleBatchPreservesSemantics) {
+  PathExprFactory<int> F;
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2), d = F.atom(3);
+  Ref p = F.unite(a, b);
+  Ref r1 = F.unite(F.concat(p, c), F.concat(p, d));
+  Ref r2 = F.concat(p, c);
+
+  auto imp = ean::importCanonical<int>({r1, r2});
+  PathExprFactory<int> F2;
+  auto out = ean::exportBatch<int>(imp, F2);
+
+  ASSERT_EQ(out.size(), 2u);
+  EXPECT_TRUE(eval(r1) == eval(out[0]));
+  EXPECT_TRUE(eval(r2) == eval(out[1]));
+}
+
+// I2: choice is ACI, so a⊕b and b⊕a land in the same e-class.
+TEST(EanRoundtrip, ChoiceIsCanonicalizedACI) {
+  PathExprFactory<int> F;
+  Ref a = F.atom(0), b = F.atom(1);
+  Ref j1 = F.unite(a, b), j2 = F.unite(b, a);
+  auto imp = ean::importCanonical<int>({j1, j2});
+  EXPECT_EQ(imp.roots[0], imp.roots[1]);
+}
+
+TEST(EanRoundtrip, StarPreservesSemantics) {
+  PathExprFactory<int> F;
+  Ref a = F.atom(0), b = F.atom(1);
+  Ref e = F.star(F.unite(a, F.concat(a, b)));
+  auto imp = ean::importCanonical<int>({e});
+  PathExprFactory<int> F2;
+  auto out = ean::exportBatch<int>(imp, F2);
+  EXPECT_TRUE(eval(e) == eval(out[0]));
+}
+
+TEST(EanRoundtrip, RandomizedDifferential) {
+  for (int t = 0; t < 500; ++t) {
+    PathExprFactory<int> F;
+    Ref e = randExpr(F, 4);
+    auto imp = ean::importCanonical<int>({e});
+    PathExprFactory<int> F2;
+    auto out = ean::exportBatch<int>(imp, F2);
+    EXPECT_TRUE(eval(e) == eval(out[0])) << "random trial " << t;
+  }
+}

--- a/tests/unit/Dataflow/APA/EAN/SaturateTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/SaturateTest.cpp
@@ -1,0 +1,159 @@
+// EAN M3 tests: the top-level budgeted saturation pipeline `ean()`.
+//
+// Checks: (1) it reduces the retained DAG and cost on a factorable batch while
+// preserving the boolean-matrix interpretation; (2) budgets stop it early yet
+// still yield a valid (anytime) result; (3) an empty law profile is a
+// semantics-preserving no-op; (4) it never changes semantics on random batches
+// and terminates.
+
+#include "Dataflow/APA/EAN/EAN.h"
+
+#include "BoolKleene.h"
+
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace lotus_test_ean;
+namespace ean = elimination::ean;
+using ean::Budget;
+using ean::CostModel;
+using ean::LawProfile;
+using ean::SaturationStats;
+using ean::StopReason;
+using Factory = elimination::PathExprFactory<int>;
+using Ref = Factory::Ref;
+
+// Count distinct hash-consed nodes reachable from a Ref.
+void collectUnique(const Ref &e, std::unordered_set<const void *> &seen) {
+  if (!e || !seen.insert(e.get()).second) return;
+  if (e->L) collectUnique(e->L, seen);
+  if (e->R) collectUnique(e->R, seen);
+}
+std::size_t countUnique(const Ref &e) {
+  std::unordered_set<const void *> seen;
+  collectUnique(e, seen);
+  return seen.size();
+}
+
+Ref seq4(Factory &F, Ref w, Ref x, Ref y, Ref z) {
+  return F.concat(F.concat(F.concat(w, x), y), z);
+}
+
+// (a·b·c·d) ⊕ (a·b·c·e) ⊕ (a·b·c·f): a long prefix shared across 3 branches.
+Ref threeBranch(Factory &F) {
+  Ref a = F.atom(0), b = F.atom(1), c = F.atom(2);
+  Ref d = F.atom(3), e = F.atom(4), f = F.atom(5);
+  return F.unite(F.unite(seq4(F, a, b, c, d), seq4(F, a, b, c, e)),
+                 seq4(F, a, b, c, f));
+}
+
+std::uint64_t g_seed = 0xBEEF77;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+Ref randExpr(Factory &F, int depth) {
+  if (depth <= 0 || (rnd() % 3 == 0)) return F.atom(static_cast<int>(rnd() % 5));
+  switch (rnd() % 4) {
+  case 0: return F.unite(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 1: return F.concat(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 2: return F.star(randExpr(F, depth - 1));
+  default: return F.atom(static_cast<int>(rnd() % 5));
+  }
+}
+
+} // namespace
+
+TEST(EanSaturate, ReducesNodesAndPreservesSemantics) {
+  Factory F;
+  Ref r = threeBranch(F);
+  const Mat before = evalRef(r);
+  const std::size_t origUnique = countUnique(r);
+
+  Factory G;
+  SaturationStats st;
+  auto out = ean::ean<int>({r}, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                           Budget::unbounded(), G, &st);
+
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_TRUE(evalRef(out[0]) == before);
+  EXPECT_LT(countUnique(out[0]), origUnique);
+  EXPECT_LT(st.finalCost, st.initCost);
+  EXPECT_GT(st.rounds, 0u);
+}
+
+TEST(EanSaturate, RoundBudgetStopsEarlyButValid) {
+  Factory F;
+  Ref r = threeBranch(F);
+  const Mat before = evalRef(r);
+
+  Budget b;
+  b.roundLimit = 1;
+  Factory G;
+  SaturationStats st;
+  auto out = ean::ean<int>({r}, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                           b, G, &st);
+
+  EXPECT_EQ(st.stop, StopReason::RoundLimit);
+  EXPECT_EQ(st.rounds, 1u);
+  EXPECT_TRUE(evalRef(out[0]) == before); // anytime: still a valid equivalent
+}
+
+TEST(EanSaturate, NodeBudgetStopsEarlyButValid) {
+  Factory F;
+  Ref r = threeBranch(F);
+  const Mat before = evalRef(r);
+
+  Budget b;
+  b.nodeLimit = 1; // any change pushes totalSize past this immediately
+  Factory G;
+  SaturationStats st;
+  auto out = ean::ean<int>({r}, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                           b, G, &st);
+
+  EXPECT_EQ(st.stop, StopReason::NodeLimit);
+  EXPECT_TRUE(evalRef(out[0]) == before);
+}
+
+TEST(EanSaturate, EmptyProfileIsSemanticsPreservingNoOp) {
+  Factory F;
+  Ref r = threeBranch(F);
+  const Mat before = evalRef(r);
+
+  Factory G;
+  SaturationStats st;
+  auto out = ean::ean<int>({r}, LawProfile::none(), CostModel::uniform(),
+                           Budget::unbounded(), G, &st);
+
+  EXPECT_EQ(st.rounds, 0u);
+  EXPECT_EQ(st.stop, StopReason::Saturated);
+  EXPECT_TRUE(evalRef(out[0]) == before);
+}
+
+TEST(EanSaturate, RandomizedDifferentialBatch) {
+  for (int t = 0; t < 400; ++t) {
+    Factory F;
+    std::vector<Ref> R;
+    std::vector<Mat> before;
+    const int k = 1 + static_cast<int>(rnd() % 3); // 1..3 roots
+    for (int i = 0; i < k; ++i) {
+      Ref e = randExpr(F, 4);
+      R.push_back(e);
+      before.push_back(evalRef(e));
+    }
+    Budget b = Budget::unbounded();
+    b.roundLimit = 200; // safety net against pathological growth
+
+    Factory G;
+    auto out = ean::ean<int>(R, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                             b, G);
+    ASSERT_EQ(out.size(), R.size()) << "trial " << t;
+    for (std::size_t i = 0; i < R.size(); ++i) {
+      EXPECT_TRUE(evalRef(out[i]) == before[i]) << "trial " << t << " root " << i;
+    }
+  }
+}

--- a/tests/unit/Dataflow/APA/EAN/SolverWiringTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/SolverWiringTest.cpp
@@ -1,0 +1,213 @@
+// EAN M6 tests: wiring EAN into the intraprocedural APA solver.
+//
+// Verifies (RQ1 correctness) that enabling EAN does not change any client fact:
+//  * distributive domain (reachability) with the full Kleene profile — results
+//    identical, and the retained path-expression DAG shrinks;
+//  * non-distributive domain (a mod-2 constant lattice) with the universally
+//    safe default profile (left distributivity only) — results identical.
+// It also documents WHY the default is safe-minimal: enabling right
+// distributivity on the non-distributive domain would change the result.
+//
+// LLVM-free: uses toy AnalysisDomains directly on the generic solver.
+
+#include "Dataflow/APA/Solver/Solver.h"
+
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using elimination::EliminationOptions;
+using elimination::IntraEliminationProblem;
+using elimination::IntraEliminationSolver;
+namespace ean = elimination::ean;
+
+using Ref = elimination::PathExprFactory<int>::Ref;
+
+void collectExpr(const Ref &e, std::unordered_set<const void *> &seen) {
+  if (!e || !seen.insert(e.get()).second) return;
+  if (e->L) collectExpr(e->L, seen);
+  if (e->R) collectExpr(e->R, seen);
+}
+template <typename ResT> std::size_t uniqueExprNodes(const ResT &r) {
+  std::unordered_set<const void *> seen;
+  for (const auto &N : r.nodes()) collectExpr(r.ExprTo(N), seen);
+  return seen.size();
+}
+
+// ---- distributive reachability domain (meet = set union) -------------------
+struct ReachDomain {
+  using n_t = int;
+  using fact_t = std::set<int>;
+  using transfer_t = int;
+  using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+};
+class ReachProblem final : public IntraEliminationProblem<ReachDomain> {
+public:
+  explicit ReachProblem(std::unordered_map<int, std::vector<int>> S)
+      : Succs(std::move(S)) {}
+  std::vector<int> nodes() const override {
+    std::vector<int> Ns;
+    for (auto &kv : Succs) Ns.push_back(kv.first);
+    return Ns;
+  }
+  int entry() const override { return 0; }
+  std::vector<int> succs(int n) const override {
+    auto it = Succs.find(n);
+    return it == Succs.end() ? std::vector<int>{} : it->second;
+  }
+  int edgeTransfer(int, int Dst) const override { return Dst; }
+  fact_t applyTransfer(const int &T, const fact_t &In) const override {
+    fact_t o = In;
+    o.insert(T);
+    return o;
+  }
+  fact_t join(const fact_t &a, const fact_t &b) const override {
+    fact_t o = a;
+    o.insert(b.begin(), b.end());
+    return o;
+  }
+  bool equal(const fact_t &a, const fact_t &b) const override { return a == b; }
+  fact_t bottom() const override { return {}; }
+  fact_t initialFact() const override { return {}; }
+
+private:
+  std::unordered_map<int, std::vector<int>> Succs;
+};
+
+// ---- non-distributive mod-2 constant lattice -------------------------------
+// fact: BOT (no info) < constant < TOP (conflict). transfer >=0 sets that
+// constant; transfer -1 maps a value to (value % 2). mod-2 is many-to-one, so
+// it does NOT distribute over meet (e.g. mod2(2 ⊔ 4) = mod2(TOP) = TOP, but
+// mod2(2) ⊔ mod2(4) = 0 ⊔ 0 = 0).
+constexpr int BOT = -100;
+constexpr int TOP = -200;
+struct Mod2Domain {
+  using n_t = int;
+  using fact_t = int;
+  using transfer_t = int;
+  using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+};
+class Mod2Problem final : public IntraEliminationProblem<Mod2Domain> {
+public:
+  Mod2Problem(std::unordered_map<int, std::vector<int>> S,
+              std::map<std::pair<int, int>, int> E)
+      : Succs(std::move(S)), Edge(std::move(E)) {}
+  std::vector<int> nodes() const override {
+    std::vector<int> Ns;
+    for (auto &kv : Succs) Ns.push_back(kv.first);
+    return Ns;
+  }
+  int entry() const override { return 0; }
+  std::vector<int> succs(int n) const override {
+    auto it = Succs.find(n);
+    return it == Succs.end() ? std::vector<int>{} : it->second;
+  }
+  int edgeTransfer(int Src, int Dst) const override {
+    return Edge.at({Src, Dst});
+  }
+  fact_t applyTransfer(const int &T, const fact_t &In) const override {
+    if (T >= 0) return T; // set constant
+    if (In == BOT) return BOT;
+    if (In == TOP) return TOP;
+    return In % 2; // mod2
+  }
+  fact_t join(const fact_t &a, const fact_t &b) const override {
+    if (a == BOT) return b;
+    if (b == BOT) return a;
+    if (a == TOP || b == TOP) return TOP;
+    return a == b ? a : TOP;
+  }
+  bool equal(const fact_t &a, const fact_t &b) const override { return a == b; }
+  fact_t bottom() const override { return BOT; }
+  fact_t initialFact() const override { return BOT; }
+
+private:
+  std::unordered_map<int, std::vector<int>> Succs;
+  std::map<std::pair<int, int>, int> Edge;
+};
+
+} // namespace
+
+// Distributive client + full profile: results identical, DAG no larger.
+TEST(EanWiring, DistributiveResultsUnchangedAndSmaller) {
+  // diamond: 0 -> {1,2} -> 3 ; edges into 3 share the same atom (Dst=3).
+  std::unordered_map<int, std::vector<int>> S = {
+      {0, {1, 2}}, {1, {3}}, {2, {3}}, {3, {}}};
+
+  ReachProblem P0(S);
+  IntraEliminationSolver<ReachDomain> Off(P0);
+  Off.solve();
+  const auto &ROff = Off.getResults();
+
+  EliminationOptions Opts;
+  Opts.EnableEAN = true;
+  Opts.EANLaws = ean::LawProfile::kleeneAlgebra(); // reachability is distributive
+  ReachProblem P1(S);
+  IntraEliminationSolver<ReachDomain> On(P1, Opts);
+  On.solve();
+  const auto &ROn = On.getResults();
+
+  for (int n : {0, 1, 2, 3}) {
+    const auto *a = ROff.tryIN(n);
+    const auto *b = ROn.tryIN(n);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+    EXPECT_EQ(*a, *b) << "node " << n;
+  }
+  EXPECT_LE(uniqueExprNodes(ROn), uniqueExprNodes(ROff));
+}
+
+// Non-distributive client + safe-minimal default profile: results identical.
+TEST(EanWiring, NonDistributiveSafeMinimalPreservesResults) {
+  std::unordered_map<int, std::vector<int>> S = {
+      {0, {1, 2}}, {1, {3}}, {2, {3}}, {3, {}}};
+  std::map<std::pair<int, int>, int> E = {
+      {{0, 1}, 2}, {{0, 2}, 4}, {{1, 3}, -1}, {{2, 3}, -1}}; // set2/set4 then mod2
+
+  Mod2Problem P0(S, E);
+  IntraEliminationSolver<Mod2Domain> Off(P0);
+  Off.solve();
+  const auto &ROff = Off.getResults();
+
+  EliminationOptions Opts;
+  Opts.EnableEAN = true; // default EANLaws = safeMinimal() (left distributivity)
+  Mod2Problem P1(S, E);
+  IntraEliminationSolver<Mod2Domain> On(P1, Opts);
+  On.solve();
+  const auto &ROn = On.getResults();
+
+  ASSERT_NE(ROff.tryIN(3), nullptr);
+  EXPECT_EQ(*ROff.tryIN(3), 0); // mod2(2)=mod2(4)=0, meet=0
+  for (int n : {0, 1, 2, 3}) {
+    ASSERT_NE(ROn.tryIN(n), nullptr);
+    EXPECT_EQ(*ROn.tryIN(n), *ROff.tryIN(n)) << "node " << n;
+  }
+}
+
+// Documents why the default is safe-minimal: right distributivity is UNSOUND on
+// this non-distributive client and changes the result.
+TEST(EanWiring, RightDistributivityUnsoundOnNonDistributive) {
+  std::unordered_map<int, std::vector<int>> S = {
+      {0, {1, 2}}, {1, {3}}, {2, {3}}, {3, {}}};
+  std::map<std::pair<int, int>, int> E = {
+      {{0, 1}, 2}, {{0, 2}, 4}, {{1, 3}, -1}, {{2, 3}, -1}};
+
+  EliminationOptions Opts;
+  Opts.EnableEAN = true;
+  Opts.EANLaws = ean::LawProfile::kleeneAlgebra(); // WRONG for this client
+  Mod2Problem P(S, E);
+  IntraEliminationSolver<Mod2Domain> On(P, Opts);
+  On.solve();
+  const auto &R = On.getResults();
+
+  ASSERT_NE(R.tryIN(3), nullptr);
+  // (set2 ⊕ set4)·mod2 = mod2(meet(2,4)=TOP) = TOP, vs the correct 0.
+  EXPECT_EQ(*R.tryIN(3), TOP);
+}

--- a/tests/unit/Dataflow/APA/EAN/StarTest.cpp
+++ b/tests/unit/Dataflow/APA/EAN/StarTest.cpp
@@ -1,0 +1,121 @@
+// EAN M5 tests: Kleene sliding  (a·b)*·a = a·(b·a)*  in the Star phase.
+
+#include "Dataflow/APA/EAN/EAN.h"
+#include "Dataflow/APA/EAN/Export.h"
+#include "Dataflow/APA/EAN/Import.h"
+#include "Dataflow/APA/EAN/Star.h"
+
+#include "BoolKleene.h"
+#include "EanGraphEval.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace lotus_test_ean;
+namespace ean = elimination::ean;
+using ean::CostModel;
+using ean::ExtractOptions;
+using ean::Id;
+using ean::Law;
+using ean::LawProfile;
+using Factory = elimination::PathExprFactory<int>;
+using Ref = Factory::Ref;
+
+// (a·b)*·a
+Ref slideInput(Factory &F) {
+  Ref a = F.atom(0), b = F.atom(1);
+  return F.concat(F.star(F.concat(a, b)), a);
+}
+
+std::uint64_t g_seed = 0x571DE;
+std::uint32_t rnd() {
+  g_seed = g_seed * 6364136223846793005ull + 1442695040888963407ull;
+  return static_cast<std::uint32_t>(g_seed >> 33);
+}
+Ref randExpr(Factory &F, int depth) {
+  if (depth <= 0 || (rnd() % 3 == 0)) return F.atom(static_cast<int>(rnd() % 4));
+  switch (rnd() % 4) {
+  case 0: return F.unite(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 1: return F.concat(randExpr(F, depth - 1), randExpr(F, depth - 1));
+  case 2: return F.star(randExpr(F, depth - 1));
+  default: return F.atom(static_cast<int>(rnd() % 4));
+  }
+}
+
+} // namespace
+
+TEST(EanStar, SlideAppearsAndPreservesSemantics) {
+  Factory F;
+  Ref r = slideInput(F);
+  const Mat before = evalRef(r);
+
+  auto imp = ean::importCanonical<int>({r});
+  ASSERT_EQ(imp.g[imp.roots[0]].nodes.size(), 1u);
+  const std::size_t changed = ean::slideRound(imp.g, LawProfile::kleeneAlgebra());
+
+  EXPECT_GT(changed, 0u);
+  EXPECT_GE(imp.g[imp.roots[0]].nodes.size(), 2u); // slid form added
+  EXPECT_TRUE(allClassesConsistent(imp.g, imp.atoms));
+
+  Factory G;
+  auto out = ean::exportBatch<int>(imp, G);
+  EXPECT_TRUE(evalRef(out[0]) == before);
+}
+
+TEST(EanStar, LawProfileGatesSliding) {
+  Factory F;
+  Ref r = slideInput(F);
+  auto imp = ean::importCanonical<int>({r});
+
+  LawProfile noSlide = LawProfile::kleeneAlgebra();
+  noSlide.disable(Law::Sliding);
+  EXPECT_EQ(ean::slideRound(imp.g, noSlide), 0u);
+  EXPECT_EQ(imp.g[imp.roots[0]].nodes.size(), 1u);
+
+  EXPECT_GT(ean::slideRound(imp.g, LawProfile::kleeneAlgebra()), 0u);
+  EXPECT_GE(imp.g[imp.roots[0]].nodes.size(), 2u);
+}
+
+TEST(EanStar, EndToEndBothPlateauModes) {
+  for (ExtractOptions::PlateauCost mode :
+       {ExtractOptions::PlateauCost::Tree, ExtractOptions::PlateauCost::Dag}) {
+    Factory F;
+    Ref r = slideInput(F);
+    const Mat before = evalRef(r);
+
+    ExtractOptions opts;
+    opts.plateauMode = mode;
+    Factory G;
+    auto out = ean::ean<int>({r}, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                             ean::Budget::unbounded(), G, nullptr, opts);
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_TRUE(evalRef(out[0]) == before);
+  }
+}
+
+TEST(EanStar, RandomizedDifferentialWithStars) {
+  for (int t = 0; t < 400; ++t) {
+    Factory F;
+    std::vector<Ref> R;
+    std::vector<Mat> before;
+    const int k = 1 + static_cast<int>(rnd() % 3);
+    for (int i = 0; i < k; ++i) {
+      Ref e = randExpr(F, 4);
+      R.push_back(e);
+      before.push_back(evalRef(e));
+    }
+    ean::Budget b = ean::Budget::unbounded();
+    b.roundLimit = 300;
+
+    Factory G;
+    auto out = ean::ean<int>(R, LawProfile::kleeneAlgebra(), CostModel::uniform(),
+                             b, G);
+    ASSERT_EQ(out.size(), R.size()) << "trial " << t;
+    for (std::size_t i = 0; i < R.size(); ++i) {
+      EXPECT_TRUE(evalRef(out[i]) == before[i]) << "trial " << t << " root " << i;
+    }
+  }
+}

--- a/tests/unit/Dataflow/APA/InterSummaryTransferTest.cpp
+++ b/tests/unit/Dataflow/APA/InterSummaryTransferTest.cpp
@@ -133,3 +133,29 @@ TEST(InterSummaryTransferEvaluator, EvaluatesSummaryTransferExpressions) {
   // returnExit: 17 + 10 + 2 + 30 + 11 = 70.
   EXPECT_EQ(Evaluator.evaluateExpr(Expr, 5), 70);
 }
+
+TEST(InterSummaryTransferAtom, SummaryCallEqualityAndHashConsing) {
+  using Atom = elimination::InterSummaryTransferAtom<FakeDomain>;
+  using Factory = elimination::PathExprFactory<Atom>;
+
+  const auto A = Atom::summaryCall(/*CallSite=*/10, /*Callee=*/2,
+                                   /*RetSite=*/11);
+  const auto ASame = Atom::summaryCall(10, 2, 11);
+  const auto BDiff = Atom::summaryCall(10, 3, 11); // different callee
+
+  // Value equality over the discriminant fields.
+  EXPECT_TRUE(A == ASame);
+  EXPECT_FALSE(A == BDiff);
+  EXPECT_TRUE(A != BDiff);
+
+  // A SummaryCall never equals another kind sharing the same numeric fields.
+  EXPECT_FALSE(A == Atom::callToRet(10, 11, {2}));
+
+  // std::hash agrees with operator== on equal atoms.
+  EXPECT_EQ((std::hash<Atom>{}(A)), (std::hash<Atom>{}(ASame)));
+
+  // Factory hash-conses equal atoms to the same node, distinct atoms apart.
+  Factory Exprs;
+  EXPECT_EQ(Exprs.atom(A), Exprs.atom(ASame));
+  EXPECT_NE(Exprs.atom(A), Exprs.atom(BDiff));
+}

--- a/tests/unit/Dataflow/APA/ModularInterSummaryDriverTest.cpp
+++ b/tests/unit/Dataflow/APA/ModularInterSummaryDriverTest.cpp
@@ -1,0 +1,290 @@
+#include "Dataflow/APA/Solver/ModularInterSummaryDriver.h"
+
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using Fwd = dataflow::controlflow::FlowDirection;
+
+// Reachability-style domain over int nodes: fact 1 = reachable, 0 = top.
+//   main: 1(entry) -> 2(call id) -> 3(exit)
+//   id:   11(entry) -> 12(exit)
+struct FakeICF {
+  bool isCallSite(int I) const { return I == 2; }
+  std::vector<int> getAllInstructionsOf(int F) const {
+    if (F == 100) return {1, 2, 3};
+    if (F == 200) return {11, 12};
+    return {};
+  }
+  std::vector<int> getSuccsOf(int I, Fwd) const {
+    if (I == 1) return {2};
+    if (I == 11) return {12};
+    return {};
+  }
+  std::vector<int> getStartPointsOf(int F) const {
+    if (F == 100) return {1};
+    if (F == 200) return {11};
+    return {};
+  }
+  std::vector<int> getExitPointsOf(int F) const {
+    if (F == 100) return {3};
+    if (F == 200) return {12};
+    return {};
+  }
+  std::vector<int> getReturnSitesOfCallAt(int C) const {
+    return C == 2 ? std::vector<int>{3} : std::vector<int>{};
+  }
+  std::vector<int> getCalleesOfCallAt(int C) const {
+    return C == 2 ? std::vector<int>{200} : std::vector<int>{};
+  }
+};
+
+struct FakeDomain {
+  using n_t = int; using fact_t = int; using transfer_t = int;
+  using f_t = int; using i_t = FakeICF;
+  using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+};
+
+class FakeProblem : public elimination::InterEliminationProblem<FakeDomain> {
+public:
+  FakeProblem()
+      : elimination::InterEliminationProblem<FakeDomain>({100}, nullptr) {}
+  fact_t normalFlow(n_t, const fact_t &In) override { return In; }
+  fact_t join(const fact_t &L, const fact_t &R) const override {
+    return L > R ? L : R; // reachability: OR
+  }
+  bool equal(const fact_t &L, const fact_t &R) const override {
+    return L == R;
+  }
+  fact_t bottom() const override { return 0; }
+  n_t transferSuccessor(const transfer_t &) const override { return 0; }
+  std::unordered_map<n_t, fact_t> initialSeeds() override { return {}; }
+  // callFlow/returnFlow just propagate reachability across the boundary.
+  fact_t callFlow(n_t, f_t, const fact_t &In) override { return In; }
+  fact_t returnFlow(n_t, f_t, n_t, n_t, const fact_t &In) override {
+    return In;
+  }
+  fact_t callToRetFlow(n_t, n_t, const std::vector<f_t> &,
+                       const fact_t &In) override {
+    return In;
+  }
+  std::vector<f_t> getCalleesOfCallAt(n_t C) const override {
+    return C == 2 ? std::vector<f_t>{200} : std::vector<f_t>{};
+  }
+};
+
+using Driver = elimination::ModularInterSummaryDriver<FakeDomain, 2>;
+using Context = elimination::InterDataFlowResultT<2, int, int, int>::Context;
+
+TEST(ModularInterSummaryDriver, ReachabilityPropagatesThroughCall) {
+  FakeICF ICF;
+  FakeProblem Problem;
+  Driver D(Problem, ICF);
+  auto R = D.solve({100}, /*InitialFact=*/1);
+
+  const Context Empty{};
+  // main entry and exit reachable.
+  ASSERT_NE(R.tryIN(1, Empty), nullptr);
+  EXPECT_EQ(*R.tryIN(1, Empty), 1);
+  EXPECT_EQ(*R.tryIN(3, Empty), 1);
+  // callee id reachable through the SummaryCall/callFlow path.
+  ASSERT_NE(R.tryIN(11, Empty), nullptr);
+  EXPECT_EQ(*R.tryIN(11, Empty), 1);
+  EXPECT_EQ(*R.tryIN(12, Empty), 1);
+}
+
+// D4: enabling per-procedure EAN must not change the interpreted facts. EAN is
+// a semantics-preserving optimization of the summary batch, so reachability is
+// identical to the EAN-off run above.
+TEST(ModularInterSummaryDriver, PerProcedureEANPreservesFacts) {
+  FakeICF ICF;
+  FakeProblem Problem;
+  elimination::PathSummaryEquationOptions Opts;
+  Opts.EAN.EnableEAN = true;
+  Driver D(Problem, ICF, Opts);
+  auto R = D.solve({100}, /*InitialFact=*/1);
+
+  const Context Empty{};
+  ASSERT_NE(R.tryIN(1, Empty), nullptr);
+  EXPECT_EQ(*R.tryIN(1, Empty), 1);
+  EXPECT_EQ(*R.tryIN(3, Empty), 1);
+  ASSERT_NE(R.tryIN(11, Empty), nullptr);
+  EXPECT_EQ(*R.tryIN(11, Empty), 1);
+  EXPECT_EQ(*R.tryIN(12, Empty), 1);
+}
+
+TEST(ModularInterSummaryDriver, RecursionTerminatesAndReachesFixpoint) {
+  // Self-recursive: main -> main. Fixpoint must terminate; entry reachable.
+  struct RecICF {
+    bool isCallSite(int I) const { return I == 2; }
+    std::vector<int> getAllInstructionsOf(int F) const {
+      return F == 100 ? std::vector<int>{1, 2, 3} : std::vector<int>{};
+    }
+    std::vector<int> getSuccsOf(int I, Fwd) const {
+      return I == 1 ? std::vector<int>{2} : std::vector<int>{};
+    }
+    std::vector<int> getStartPointsOf(int F) const {
+      return F == 100 ? std::vector<int>{1} : std::vector<int>{};
+    }
+    std::vector<int> getExitPointsOf(int F) const {
+      return F == 100 ? std::vector<int>{3} : std::vector<int>{};
+    }
+    std::vector<int> getReturnSitesOfCallAt(int C) const {
+      return C == 2 ? std::vector<int>{3} : std::vector<int>{};
+    }
+    std::vector<int> getCalleesOfCallAt(int C) const {
+      return C == 2 ? std::vector<int>{100} : std::vector<int>{};
+    }
+  };
+  struct RecDomain {
+    using n_t = int; using fact_t = int; using transfer_t = int;
+    using f_t = int; using i_t = RecICF;
+    using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+  };
+  class RecProblem : public elimination::InterEliminationProblem<RecDomain> {
+  public:
+    RecProblem()
+        : elimination::InterEliminationProblem<RecDomain>({100}, nullptr) {}
+    fact_t normalFlow(n_t, const fact_t &In) override { return In; }
+    fact_t join(const fact_t &L, const fact_t &R) const override {
+      return L > R ? L : R;
+    }
+    bool equal(const fact_t &L, const fact_t &R) const override {
+      return L == R;
+    }
+    fact_t bottom() const override { return 0; }
+    n_t transferSuccessor(const transfer_t &) const override { return 0; }
+    std::unordered_map<n_t, fact_t> initialSeeds() override { return {}; }
+    fact_t callFlow(n_t, f_t, const fact_t &In) override { return In; }
+    fact_t returnFlow(n_t, f_t, n_t, n_t, const fact_t &In) override {
+      return In;
+    }
+    fact_t callToRetFlow(n_t, n_t, const std::vector<f_t> &,
+                         const fact_t &In) override {
+      return In;
+    }
+    std::vector<f_t> getCalleesOfCallAt(n_t C) const override {
+      return C == 2 ? std::vector<f_t>{100} : std::vector<f_t>{};
+    }
+  };
+
+  RecICF ICF;
+  RecProblem Problem;
+  elimination::ModularInterSummaryDriver<RecDomain, 2> D(Problem, ICF);
+  auto R = D.solve({100}, 1); // must terminate
+
+  const elimination::InterDataFlowResultT<2, int, int, int>::Context Empty{};
+  ASSERT_NE(R.tryIN(1, Empty), nullptr);
+  EXPECT_EQ(*R.tryIN(1, Empty), 1);
+}
+
+// Regression: reachability must flow the full depth of a call chain
+//   main(100) -> A(200) -> B(300) -> C(400)
+// The deepest callee C is reached only after entry facts propagate three hops.
+// Because the driver processes callees before callers (one hop per pass), the
+// outer fixpoint must NOT stop while entry facts are still moving. Watching only
+// the interpreter's recursion-memo "changed" flag broke here: C stayed
+// unreachable (mirrors the dirname main->version_etc->version_etc_va->
+// version_etc_arn under-approximation).
+TEST(ModularInterSummaryDriver, ReachabilityFlowsDeepCallChain) {
+  struct ChainICF {
+    bool isCallSite(int I) const { return I == 2 || I == 12 || I == 22; }
+    std::vector<int> getAllInstructionsOf(int F) const {
+      if (F == 100) return {1, 2, 3};
+      if (F == 200) return {11, 12, 13};
+      if (F == 300) return {21, 22, 23};
+      if (F == 400) return {31, 32};
+      return {};
+    }
+    std::vector<int> getSuccsOf(int I, Fwd) const {
+      if (I == 1) return {2};
+      if (I == 2) return {3};
+      if (I == 11) return {12};
+      if (I == 12) return {13};
+      if (I == 21) return {22};
+      if (I == 22) return {23};
+      if (I == 31) return {32};
+      return {};
+    }
+    std::vector<int> getStartPointsOf(int F) const {
+      if (F == 100) return {1};
+      if (F == 200) return {11};
+      if (F == 300) return {21};
+      if (F == 400) return {31};
+      return {};
+    }
+    std::vector<int> getExitPointsOf(int F) const {
+      if (F == 100) return {3};
+      if (F == 200) return {13};
+      if (F == 300) return {23};
+      if (F == 400) return {32};
+      return {};
+    }
+    std::vector<int> getReturnSitesOfCallAt(int C) const {
+      if (C == 2) return {3};
+      if (C == 12) return {13};
+      if (C == 22) return {23};
+      return {};
+    }
+    std::vector<int> getCalleesOfCallAt(int C) const {
+      if (C == 2) return {200};
+      if (C == 12) return {300};
+      if (C == 22) return {400};
+      return {};
+    }
+  };
+  struct ChainDomain {
+    using n_t = int; using fact_t = int; using transfer_t = int;
+    using f_t = int; using i_t = ChainICF;
+    using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+  };
+  class ChainProblem : public elimination::InterEliminationProblem<ChainDomain> {
+  public:
+    ChainProblem()
+        : elimination::InterEliminationProblem<ChainDomain>({100}, nullptr) {}
+    fact_t normalFlow(n_t, const fact_t &In) override { return In; }
+    fact_t join(const fact_t &L, const fact_t &R) const override {
+      return L > R ? L : R;
+    }
+    bool equal(const fact_t &L, const fact_t &R) const override {
+      return L == R;
+    }
+    fact_t bottom() const override { return 0; }
+    n_t transferSuccessor(const transfer_t &) const override { return 0; }
+    std::unordered_map<n_t, fact_t> initialSeeds() override { return {}; }
+    fact_t callFlow(n_t, f_t, const fact_t &In) override { return In; }
+    fact_t returnFlow(n_t, f_t, n_t, n_t, const fact_t &In) override {
+      return In;
+    }
+    fact_t callToRetFlow(n_t, n_t, const std::vector<f_t> &,
+                         const fact_t &In) override {
+      return In;
+    }
+    std::vector<f_t> getCalleesOfCallAt(n_t C) const override {
+      if (C == 2) return {200};
+      if (C == 12) return {300};
+      if (C == 22) return {400};
+      return {};
+    }
+  };
+
+  ChainICF ICF;
+  ChainProblem Problem;
+  elimination::ModularInterSummaryDriver<ChainDomain, 2> D(Problem, ICF);
+  auto R = D.solve({100}, 1);
+
+  const elimination::InterDataFlowResultT<2, int, int, int>::Context Empty{};
+  // Every level, including the deepest callee C, must be reachable.
+  ASSERT_NE(R.tryIN(11, Empty), nullptr);
+  EXPECT_EQ(*R.tryIN(11, Empty), 1); // A
+  ASSERT_NE(R.tryIN(21, Empty), nullptr);
+  EXPECT_EQ(*R.tryIN(21, Empty), 1); // B
+  ASSERT_NE(R.tryIN(31, Empty), nullptr);
+  EXPECT_EQ(*R.tryIN(31, Empty), 1); // C (the deepest hop)
+  EXPECT_EQ(*R.tryIN(32, Empty), 1);
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/ModularInterSummarySolverTest.cpp
+++ b/tests/unit/Dataflow/APA/ModularInterSummarySolverTest.cpp
@@ -1,0 +1,207 @@
+#include "Dataflow/APA/Solver/ModularInterSummarySolver.h"
+
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using Fwd = dataflow::controlflow::FlowDirection;
+
+// Two-procedure program:
+//   main:  1(entry) -> 2(call id) -> 3(exit)
+//   id:    11(entry) -> 12(exit)
+// Procedure ids: main=100, id=200. Instruction 0 is reserved as the null node.
+struct FakeICF {
+  bool isCallSite(int Inst) const { return Inst == 2; }
+
+  std::vector<int> getAllInstructionsOf(int F) const {
+    if (F == 100) return {1, 2, 3};
+    if (F == 200) return {11, 12};
+    return {};
+  }
+
+  std::vector<int> getSuccsOf(int Inst, Fwd) const {
+    switch (Inst) {
+    case 1: return {2};
+    case 11: return {12};
+    default: return {}; // 2 is a call site (handled via return sites), 3/12 exits
+    }
+  }
+
+  std::vector<int> getStartPointsOf(int F) const {
+    if (F == 100) return {1};
+    if (F == 200) return {11};
+    return {};
+  }
+  std::vector<int> getExitPointsOf(int F) const {
+    if (F == 100) return {3};
+    if (F == 200) return {12};
+    return {};
+  }
+  std::vector<int> getReturnSitesOfCallAt(int CallSite) const {
+    return CallSite == 2 ? std::vector<int>{3} : std::vector<int>{};
+  }
+  std::vector<int> getCalleesOfCallAt(int CallSite) const {
+    return CallSite == 2 ? std::vector<int>{200} : std::vector<int>{};
+  }
+};
+
+struct FakeDomain {
+  using n_t = int;
+  using fact_t = int;
+  using transfer_t = int;
+  using f_t = int;
+  using i_t = FakeICF;
+  using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+};
+
+class FakeProblem : public elimination::InterEliminationProblem<FakeDomain> {
+public:
+  FakeProblem() : elimination::InterEliminationProblem<FakeDomain>({100}, nullptr) {}
+  fact_t normalFlow(n_t, const fact_t &In) override { return In; }
+  fact_t join(const fact_t &L, const fact_t &R) const override {
+    return L > R ? L : R;
+  }
+  bool equal(const fact_t &L, const fact_t &R) const override {
+    return L == R;
+  }
+  // transfer_t == n_t: edgeTransfer returns Src (forward); keep default.
+  n_t transferSuccessor(const transfer_t &) const override { return 0; }
+  std::unordered_map<n_t, fact_t> initialSeeds() override { return {}; }
+  fact_t callFlow(n_t, f_t, const fact_t &In) override { return In; }
+  fact_t returnFlow(n_t, f_t, n_t, n_t, const fact_t &In) override { return In; }
+  fact_t callToRetFlow(n_t, n_t, const std::vector<f_t> &,
+                       const fact_t &In) override {
+    return In;
+  }
+  std::vector<f_t> getCalleesOfCallAt(n_t CallSite) const override {
+    return CallSite == 2 ? std::vector<f_t>{200} : std::vector<f_t>{};
+  }
+};
+
+using Builder = elimination::ModularInterSummaryBuilder<FakeDomain>;
+using Atom = elimination::InterSummaryTransferAtom<FakeDomain>;
+using ExprRef = elimination::PathExprFactory<Atom>::Ref;
+
+// True iff the expression DAG contains a SummaryCall atom for the given callee.
+bool containsSummaryCall(const ExprRef &E, int Callee) {
+  if (!E) return false;
+  using Kind = elimination::PathExprFactory<Atom>::Kind;
+  switch (E->K) {
+  case Kind::Atom:
+    return E->Transfer->K == Atom::Kind::SummaryCall &&
+           E->Transfer->Callee == Callee;
+  case Kind::Union:
+  case Kind::Concat:
+    return containsSummaryCall(E->L, Callee) ||
+           containsSummaryCall(E->R, Callee);
+  case Kind::Star:
+    return containsSummaryCall(E->L, Callee);
+  default:
+    return false;
+  }
+}
+
+TEST(ModularInterSummary, BuildsPerProcedureSummaries) {
+  FakeICF ICF;
+  FakeProblem Problem;
+  Builder B(Problem, ICF);
+  auto R = B.build({100});
+
+  // Both procedures got a summary; callee before caller in reverse-topo order.
+  ASSERT_EQ(R.summaries.size(), 2u);
+  ASSERT_TRUE(R.summaries.count(100));
+  ASSERT_TRUE(R.summaries.count(200));
+  ASSERT_EQ(R.callGraph.order.size(), 2u);
+  EXPECT_EQ(R.callGraph.order.front().procs.front(), 200); // id first (leaf)
+  EXPECT_EQ(R.callGraph.order.back().procs.front(), 100);  // main last
+
+  // main's entry->exit summary references id symbolically (not inlined).
+  const auto &Main = R.summaries.at(100);
+  ASSERT_TRUE(Main.exit != nullptr);
+  EXPECT_TRUE(containsSummaryCall(Main.exit, /*Callee=*/200));
+
+  // id's summary is a leaf: no SummaryCall atoms.
+  const auto &Id = R.summaries.at(200);
+  ASSERT_TRUE(Id.exit != nullptr);
+  EXPECT_FALSE(containsSummaryCall(Id.exit, 200));
+
+  // Per-node coverage: every instruction of each procedure has an expression.
+  EXPECT_EQ(Main.perNode.size(), 3u);
+  EXPECT_EQ(Id.perNode.size(), 2u);
+}
+
+TEST(ModularInterSummary, RecursionIsSymbolicNotInlined) {
+  // A self-recursive procedure: its summary references itself via SummaryCall,
+  // and construction terminates (no inlining, no infinite expansion).
+  struct RecICF {
+    bool isCallSite(int Inst) const { return Inst == 2; }
+    std::vector<int> getAllInstructionsOf(int F) const {
+      return F == 100 ? std::vector<int>{1, 2, 3} : std::vector<int>{};
+    }
+    std::vector<int> getSuccsOf(int Inst, Fwd) const {
+      return Inst == 1 ? std::vector<int>{2} : std::vector<int>{};
+    }
+    std::vector<int> getStartPointsOf(int F) const {
+      return F == 100 ? std::vector<int>{1} : std::vector<int>{};
+    }
+    std::vector<int> getExitPointsOf(int F) const {
+      return F == 100 ? std::vector<int>{3} : std::vector<int>{};
+    }
+    std::vector<int> getReturnSitesOfCallAt(int C) const {
+      return C == 2 ? std::vector<int>{3} : std::vector<int>{};
+    }
+    std::vector<int> getCalleesOfCallAt(int C) const {
+      return C == 2 ? std::vector<int>{100} : std::vector<int>{}; // calls self
+    }
+  };
+  struct RecDomain {
+    using n_t = int; using fact_t = int; using transfer_t = int;
+    using f_t = int; using i_t = RecICF;
+    using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+  };
+  class RecProblem : public elimination::InterEliminationProblem<RecDomain> {
+  public:
+    RecProblem() : elimination::InterEliminationProblem<RecDomain>({100}, nullptr) {}
+    fact_t normalFlow(n_t, const fact_t &In) override { return In; }
+    fact_t join(const fact_t &L, const fact_t &R) const override { return L > R ? L : R; }
+    bool equal(const fact_t &L, const fact_t &R) const override { return L == R; }
+    n_t transferSuccessor(const transfer_t &) const override { return 0; }
+    std::unordered_map<n_t, fact_t> initialSeeds() override { return {}; }
+    fact_t callFlow(n_t, f_t, const fact_t &In) override { return In; }
+    fact_t returnFlow(n_t, f_t, n_t, n_t, const fact_t &In) override { return In; }
+    fact_t callToRetFlow(n_t, n_t, const std::vector<f_t> &, const fact_t &In) override { return In; }
+    std::vector<f_t> getCalleesOfCallAt(n_t C) const override {
+      return C == 2 ? std::vector<f_t>{100} : std::vector<f_t>{};
+    }
+  };
+
+  RecICF ICF;
+  RecProblem Problem;
+  elimination::ModularInterSummaryBuilder<RecDomain> B(Problem, ICF);
+  auto R = B.build({100});
+
+  ASSERT_EQ(R.summaries.size(), 1u);
+  ASSERT_EQ(R.callGraph.order.size(), 1u);
+  EXPECT_TRUE(R.callGraph.order.front().recursive);
+  using RAtom = elimination::InterSummaryTransferAtom<RecDomain>;
+  const auto &S = R.summaries.at(100);
+  ASSERT_TRUE(S.exit != nullptr);
+  // Self-reference present as a symbolic SummaryCall to procedure 100.
+  std::function<bool(const elimination::PathExprFactory<RAtom>::Ref &)> hasSelf =
+      [&](const elimination::PathExprFactory<RAtom>::Ref &E) -> bool {
+    using Kind = elimination::PathExprFactory<RAtom>::Kind;
+    if (!E) return false;
+    if (E->K == Kind::Atom)
+      return E->Transfer->K == RAtom::Kind::SummaryCall &&
+             E->Transfer->Callee == 100;
+    if (E->K == Kind::Star) return hasSelf(E->L);
+    return hasSelf(E->L) || hasSelf(E->R);
+  };
+  EXPECT_TRUE(hasSelf(S.exit));
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/OrderTest.cpp
+++ b/tests/unit/Dataflow/APA/OrderTest.cpp
@@ -1,0 +1,258 @@
+// Tests for cost-aware elimination ordering (paper's "Order" configuration).
+//
+// Two layers:
+//   * Combinatorial — the pure elimination-graph model in EliminationOrder.h:
+//     greedy minimum-product beats the baseline on a hub graph, is a valid
+//     permutation, and is deterministic.
+//   * Wiring/correctness — through the real solver on LLVM-free toy domains:
+//     on a distributive client the pivot order does NOT change any client fact
+//     (Floyd–Warshall closure is order-invariant); the non-distributive case
+//     is documented as an inherent APA caveat (like the EAN law profile).
+
+#include "Dataflow/APA/Solver/EliminationOrder.h"
+#include "Dataflow/APA/Solver/Solver.h"
+
+#include <algorithm>
+#include <map>
+#include <numeric>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using elimination::EliminationOptions;
+using elimination::IntraEliminationProblem;
+using elimination::IntraEliminationSolver;
+using elimination::OrderingPolicy;
+namespace order = elimination::order;
+
+// ------------------------------------------------------------ combinatorial --
+
+// Hub: sources 1..P -> hub 0 -> sinks P+1..P+Q. Eliminating the hub first costs
+// P*Q updates and P*Q fill edges; eliminating the (product-0) leaves first
+// costs nothing.
+order::EliminationGraph makeHub(std::size_t P, std::size_t Q) {
+  const std::size_t n = 1 + P + Q;
+  order::EliminationGraph g(n);
+  for (std::size_t i = 1; i <= P; ++i) g.addEdge(i, 0);
+  for (std::size_t j = 0; j < Q; ++j) g.addEdge(0, 1 + P + j);
+  return g;
+}
+
+bool isPermutation(const std::vector<std::size_t> &o, std::size_t n) {
+  if (o.size() != n) return false;
+  std::vector<std::size_t> s = o;
+  std::sort(s.begin(), s.end());
+  for (std::size_t i = 0; i < n; ++i)
+    if (s[i] != i) return false;
+  return true;
+}
+
+std::vector<std::size_t> identityOrder(std::size_t n) {
+  std::vector<std::size_t> o(n);
+  std::iota(o.begin(), o.end(), std::size_t{0});
+  return o;
+}
+
+TEST(EliminationOrderCombinatorial, CostAwareBeatsBaselineOnHub) {
+  const std::size_t P = 5, Q = 5;
+  auto g = makeHub(P, Q);
+  auto costAware = order::computeCostAwareOrder(g);
+
+  ASSERT_TRUE(isPermutation(costAware, g.n));
+
+  const auto ca = order::simulateCost(g, costAware);
+  const auto id = order::simulateCost(g, identityOrder(g.n));
+
+  // Baseline (identity) eliminates the hub first: P*Q product and fill.
+  EXPECT_DOUBLE_EQ(id.totalProduct, static_cast<double>(P * Q));
+  // Cost-aware peels the product-0 leaves first: zero product, no fill.
+  EXPECT_DOUBLE_EQ(ca.totalProduct, 0.0);
+  EXPECT_LT(ca.totalProduct, id.totalProduct);
+  EXPECT_LE(ca.peakFill, id.peakFill);
+}
+
+TEST(EliminationOrderCombinatorial, Deterministic) {
+  auto g = makeHub(6, 4);
+  EXPECT_EQ(order::computeCostAwareOrder(g), order::computeCostAwareOrder(g));
+}
+
+TEST(EliminationOrderCombinatorial, ChainNeverWorseThanIdentity) {
+  // 0->1->2->3->4 chain.
+  const std::size_t n = 5;
+  order::EliminationGraph g(n);
+  for (std::size_t i = 0; i + 1 < n; ++i) g.addEdge(i, i + 1);
+  auto ca = order::computeCostAwareOrder(g);
+  ASSERT_TRUE(isPermutation(ca, n));
+  EXPECT_LE(order::simulateCost(g, ca).totalProduct,
+            order::simulateCost(g, identityOrder(n)).totalProduct);
+}
+
+TEST(EliminationOrderCombinatorial, EmptyAndSingleton) {
+  EXPECT_TRUE(order::computeCostAwareOrder(order::EliminationGraph(0)).empty());
+  auto one = order::computeCostAwareOrder(order::EliminationGraph(1));
+  ASSERT_EQ(one.size(), 1u);
+  EXPECT_EQ(one[0], 0u);
+}
+
+// ------------------------------------------------------------ wiring domains --
+
+// Distributive reachability domain (meet = set union): pivot order cannot
+// change any client fact.
+struct ReachDomain {
+  using n_t = int;
+  using fact_t = std::set<int>;
+  using transfer_t = int;
+  using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+};
+class ReachProblem final : public IntraEliminationProblem<ReachDomain> {
+public:
+  explicit ReachProblem(std::unordered_map<int, std::vector<int>> S)
+      : Succs(std::move(S)) {}
+  std::vector<int> nodes() const override {
+    std::vector<int> Ns;
+    for (auto &kv : Succs) Ns.push_back(kv.first);
+    std::sort(Ns.begin(), Ns.end());
+    return Ns;
+  }
+  int entry() const override { return 0; }
+  std::vector<int> succs(int n) const override {
+    auto it = Succs.find(n);
+    return it == Succs.end() ? std::vector<int>{} : it->second;
+  }
+  int edgeTransfer(int, int Dst) const override { return Dst; }
+  fact_t applyTransfer(const int &T, const fact_t &In) const override {
+    fact_t o = In;
+    o.insert(T);
+    return o;
+  }
+  fact_t join(const fact_t &a, const fact_t &b) const override {
+    fact_t o = a;
+    o.insert(b.begin(), b.end());
+    return o;
+  }
+  bool equal(const fact_t &a, const fact_t &b) const override { return a == b; }
+  fact_t bottom() const override { return {}; }
+  fact_t initialFact() const override { return {}; }
+
+private:
+  std::unordered_map<int, std::vector<int>> Succs;
+};
+
+// A hub-shaped reachable CFG: entry 0 -> {1..P} -> hub H -> {sinks} -> exit.
+std::unordered_map<int, std::vector<int>> hubCFG(int P, int Q) {
+  std::unordered_map<int, std::vector<int>> S;
+  const int H = 1 + P;              // hub id
+  const int firstSink = H + 1;      // sinks firstSink..firstSink+Q-1
+  S[0] = {};
+  for (int i = 1; i <= P; ++i) {    // entry fans out to sources, sources -> hub
+    S[0].push_back(i);
+    S[i] = {H};
+  }
+  S[H] = {};
+  for (int j = 0; j < Q; ++j) {
+    const int sink = firstSink + j;
+    S[H].push_back(sink);
+    S[sink] = {};
+  }
+  return S;
+}
+
+TEST(OrderWiring, DistributivePivotOrderInvariant) {
+  auto S = hubCFG(4, 4);
+
+  ReachProblem P0(S);
+  EliminationOptions Def; // Ordering = Default
+  IntraEliminationSolver<ReachDomain> Baseline(P0, Def);
+  Baseline.solve();
+  const auto &RB = Baseline.getResults();
+
+  ReachProblem P1(S);
+  EliminationOptions Ord;
+  Ord.Ordering = OrderingPolicy::CostAware;
+  IntraEliminationSolver<ReachDomain> Cost(P1, Ord);
+  Cost.solve();
+  const auto &RC = Cost.getResults();
+
+  for (int n : P0.nodes()) {
+    const auto *a = RB.tryIN(n);
+    const auto *b = RC.tryIN(n);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+    EXPECT_EQ(*a, *b) << "node " << n;
+  }
+}
+
+// Non-distributive mod-2 constant lattice — documents that pivot order (like
+// the EAN law profile, and like the existing reverse-topo/identity choice) can
+// in principle change a non-distributive client's result. We only require that
+// CostAware still produces a valid solution; we do NOT assert equality with the
+// baseline, because divergence here is inherent to APA, not a defect.
+constexpr int BOT = -100;
+constexpr int TOP = -200;
+struct Mod2Domain {
+  using n_t = int;
+  using fact_t = int;
+  using transfer_t = int;
+  using abstract_domain_t = elimination::LegacyProblemDomain<fact_t>;
+};
+class Mod2Problem final : public IntraEliminationProblem<Mod2Domain> {
+public:
+  Mod2Problem(std::unordered_map<int, std::vector<int>> S,
+              std::map<std::pair<int, int>, int> E)
+      : Succs(std::move(S)), Edge(std::move(E)) {}
+  std::vector<int> nodes() const override {
+    std::vector<int> Ns;
+    for (auto &kv : Succs) Ns.push_back(kv.first);
+    std::sort(Ns.begin(), Ns.end());
+    return Ns;
+  }
+  int entry() const override { return 0; }
+  std::vector<int> succs(int n) const override {
+    auto it = Succs.find(n);
+    return it == Succs.end() ? std::vector<int>{} : it->second;
+  }
+  int edgeTransfer(int Src, int Dst) const override { return Edge.at({Src, Dst}); }
+  fact_t applyTransfer(const int &T, const fact_t &In) const override {
+    if (T >= 0) return T;
+    if (In == BOT) return BOT;
+    if (In == TOP) return TOP;
+    return In % 2;
+  }
+  fact_t join(const fact_t &a, const fact_t &b) const override {
+    if (a == BOT) return b;
+    if (b == BOT) return a;
+    if (a == TOP || b == TOP) return TOP;
+    return a == b ? a : TOP;
+  }
+  bool equal(const fact_t &a, const fact_t &b) const override { return a == b; }
+  fact_t bottom() const override { return BOT; }
+  fact_t initialFact() const override { return BOT; }
+
+private:
+  std::unordered_map<int, std::vector<int>> Succs;
+  std::map<std::pair<int, int>, int> Edge;
+};
+
+TEST(OrderWiring, NonDistributiveCostAwareStillSolves) {
+  std::unordered_map<int, std::vector<int>> S = {
+      {0, {1, 2}}, {1, {3}}, {2, {3}}, {3, {}}};
+  std::map<std::pair<int, int>, int> E = {
+      {{0, 1}, 2}, {{0, 2}, 4}, {{1, 3}, -1}, {{2, 3}, -1}};
+
+  Mod2Problem P(S, E);
+  EliminationOptions Ord;
+  Ord.Ordering = OrderingPolicy::CostAware;
+  IntraEliminationSolver<Mod2Domain> Cost(P, Ord);
+  Cost.solve();
+  const auto &R = Cost.getResults();
+  // A valid solution exists for every node; exact value is order-dependent for
+  // this non-distributive client and is therefore not asserted against Default.
+  for (int n : {0, 1, 2, 3}) EXPECT_NE(R.tryIN(n), nullptr) << "node " << n;
+}
+
+} // namespace

--- a/tests/unit/Dataflow/APA/PathSummaryEquationSolverTest.cpp
+++ b/tests/unit/Dataflow/APA/PathSummaryEquationSolverTest.cpp
@@ -162,3 +162,43 @@ TEST(PathSummaryEquationSolver, ForwardPathDirectionComposesAfterSource) {
   EXPECT_TRUE(containsWord(Result, "mid", "sa"));
   EXPECT_TRUE(containsWord(Result, "exit", "sab"));
 }
+
+// Large cyclic SCC (> kDenseCyclicThreshold) forces the sparse min-fill
+// Gaussian-elimination path.  A 20-node ring n0->n1->...->n19->n0 with a base
+// word at n0 must still yield the correct forward languages, matching what the
+// dense Floyd--Warshall closure would produce on a small ring.
+TEST(PathSummaryEquationSolver, LargeCyclicSCCSparsePathMatchesLanguage) {
+  Graph G;
+  auto &E = G.exprs();
+  const std::size_t N = 20; // > 16, so the solver takes the sparse branch
+  auto name = [](std::size_t I) { return "n" + std::to_string(I); };
+  // Base word "s" enters the ring at n0; every other node starts empty.
+  G.addNode(name(0), E.atom("s"));
+  for (std::size_t I = 1; I < N; ++I) {
+    G.addNode(name(I));
+  }
+  // Ring edges labelled with single distinct letters a, b, c, ...
+  for (std::size_t I = 0; I < N; ++I) {
+    std::string Lbl(1, static_cast<char>('a' + static_cast<int>(I)));
+    G.addEdge(name(I), name((I + 1) % N), E.atom(Lbl));
+  }
+
+  elimination::PathSummaryEquationOptions Options;
+  Options.Direction = elimination::PathSummaryEquationDirection::ForwardPath;
+  elimination::PathSummaryEquationSolver<std::string, std::string> Solver(
+      G, Options);
+  auto Result = Solver.solve();
+
+  // One strongly-connected component that is cyclic (confirms the sparse path
+  // exercised the cyclic branch, not the acyclic singleton one).
+  EXPECT_EQ(Result.diagnostics().scc_count, 1u);
+  EXPECT_EQ(Result.diagnostics().cyclic_scc_count, 1u);
+
+  // Forward reachability from the base at n0: X_{nk} contains s followed by the
+  // edge labels a,b,c,... up to nk (within the length-8 language bound).
+  EXPECT_TRUE(containsWord(Result, "n0", "s"));
+  EXPECT_TRUE(containsWord(Result, "n1", "sa"));
+  EXPECT_TRUE(containsWord(Result, "n2", "sab"));
+  EXPECT_TRUE(containsWord(Result, "n3", "sabc"));
+  EXPECT_TRUE(containsWord(Result, "n5", "sabcde"));
+}

--- a/tools/dataflow/lotus-dfa-apa.cpp
+++ b/tools/dataflow/lotus-dfa-apa.cpp
@@ -21,12 +21,14 @@
 #include "Dataflow/APA/Analyses/Intra/NonNull.h"
 #include "Dataflow/APA/Analyses/Intra/Reachability.h"
 #include "Dataflow/APA/Analyses/Intra/ReachingDefinitions.h"
+#include "Dataflow/APA/Analyses/Intra/IntraAffineEqualities.h"
 #include "Dataflow/APA/Analyses/Intra/Sign.h"
 #include "Dataflow/APA/Analyses/Intra/UninitializedVariables.h"
 #include "ToolSupport.h"
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <sstream>
@@ -34,6 +36,24 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+// psapi.h must follow windows.h
+#include <psapi.h>
+// windows.h defines IN/OUT as empty SAL macros, which would mangle the solver
+// result accessor Result.IN(...). Drop them.
+#undef IN
+#undef OUT
+#else
+#include <sys/resource.h>
+#endif
 
 using namespace llvm;
 
@@ -79,12 +99,183 @@ static cl::opt<unsigned> AffineMaxTrackedOpt(
              "limit)"),
     cl::init(32));
 
+// --- EAN / Order (evaluation) configuration ---------------------------------
+static cl::opt<std::string>
+    OrderingOpt("ordering",
+                cl::desc("Pivot order for state elimination: default|cost-aware"),
+                cl::init("default"));
+static cl::opt<bool> EanOpt("ean",
+                            cl::desc("Run the EAN normalizer post-pass"),
+                            cl::init(false));
+static cl::opt<bool>
+    GreedyOpt("greedy",
+              cl::desc("Run the Greedy one-pass simplifier post-pass"),
+              cl::init(false));
+static cl::opt<bool>
+    EanMonotoneOpt("ean-monotone",
+                   cl::desc("EAN returns the input if its output has more nodes"),
+                   cl::init(false));
+static cl::opt<std::string>
+    EanLawsOpt("ean-laws", cl::desc("EAN law profile: safe|kleene"),
+               cl::init("safe"));
+static cl::opt<std::string>
+    EanCostOpt("ean-cost",
+               cl::desc("EAN extraction cost: uniform|dag (dag counts edges "
+                        "≈ exported factory nodes)"),
+               cl::init("uniform"));
+static cl::opt<unsigned>
+    EanRoundLimit("ean-round-limit",
+                  cl::desc("EAN saturation round budget (0 = unbounded)"),
+                  cl::init(0));
+static cl::opt<unsigned>
+    EanNodeLimit("ean-node-limit",
+                 cl::desc("EAN e-node budget (0 = unbounded)"), cl::init(0));
+static cl::opt<double>
+    EanTimeLimit("ean-time-limit",
+                 cl::desc("EAN wall-clock budget in seconds (0 = unbounded)"),
+                 cl::init(0.0));
+static cl::opt<bool>
+    MeasurePeakOpt("measure-peak",
+                   cl::desc("Record peak construction nodes (slower)"),
+                   cl::init(false));
+static cl::opt<unsigned>
+    MaxFuncInsts("max-func-insts",
+                 cl::desc("Skip functions with more instructions (0 = no cap)"),
+                 cl::init(0));
+static cl::opt<unsigned>
+    EanMinNodes("ean-min-nodes",
+                cl::desc("Invocation gate: run EAN only if raw batch has >= N "
+                         "unique DAG nodes (0 = always)"),
+                cl::init(0));
+static cl::opt<unsigned>
+    InterpRepeat("interp-repeat",
+                 cl::desc("Interpret each summary N times (amortization, RQ2)"),
+                 cl::init(1));
+static cl::opt<unsigned>
+    RepeatOpt("repeat", cl::desc("Measured runs per function (timing median)"),
+              cl::init(1));
+static cl::opt<unsigned>
+    WarmupOpt("warmup", cl::desc("Warmup runs per function before measuring"),
+              cl::init(0));
+static cl::opt<bool> InterSummaryOpt(
+    "inter-summary",
+    cl::desc("Route interprocedural clients to the path-summary solver "
+             "(ForwardInterSummarySolver) so EAN/Greedy apply to summaries"),
+    cl::init(false));
+static cl::opt<bool> ModularInterOpt(
+    "modular-inter",
+    cl::desc("Route interprocedural reachable to the modular per-procedure "
+             "summary solver (E6, functional/context-insensitive)"),
+    cl::init(false));
+static cl::opt<bool> MemoInterpOpt(
+    "memo-interp",
+    cl::desc("Affine client only: memoizing transformer interpreter "
+             "(eval cost proportional to unique DAG nodes, not tree size)"),
+    cl::init(false));
+static cl::opt<std::string> InterpOpt(
+    "interp",
+    cl::desc("Path-expression interpreter: generic (framework eval) | translapa "
+             "(closed-form Gen/Kill semiring baseline). Applies to the reachable "
+             "and reachdef clients."),
+    cl::init("generic"));
+
 namespace {
 
 using lotus::dataflow_tool::FunctionView;
 using lotus::dataflow_tool::ValueIdMap;
 using InstructionExprFactory = elimination::PathExprFactory<Instruction *>;
 using InstructionExprRef = InstructionExprFactory::Ref;
+
+// Aggregated stage timings (microseconds) across the measured repeats.
+struct Timings final {
+  std::uint64_t gen = 0;
+  std::uint64_t norm = 0;
+  std::uint64_t interp = 0;
+  std::uint64_t end2end = 0;
+  unsigned runs = 1;
+};
+
+std::uint64_t medianOf(std::vector<std::uint64_t> V) {
+  if (V.empty())
+    return 0;
+  std::sort(V.begin(), V.end());
+  return V[V.size() / 2];
+}
+
+// Peak resident memory of this process in KiB (Table VII Peak RSS).
+std::uint64_t peakRssKb() {
+#ifdef _WIN32
+  PROCESS_MEMORY_COUNTERS PMC;
+  if (GetProcessMemoryInfo(GetCurrentProcess(), &PMC, sizeof(PMC)))
+    return static_cast<std::uint64_t>(PMC.PeakWorkingSetSize) / 1024;
+  return 0;
+#elif defined(__APPLE__)
+  struct rusage RU;
+  if (getrusage(RUSAGE_SELF, &RU) == 0)
+    return static_cast<std::uint64_t>(RU.ru_maxrss) / 1024; // bytes on macOS
+  return 0;
+#else
+  struct rusage RU;
+  if (getrusage(RUSAGE_SELF, &RU) == 0)
+    return static_cast<std::uint64_t>(RU.ru_maxrss); // KiB on Linux
+  return 0;
+#endif
+}
+
+// Build EliminationOptions from the evaluation CLI flags.
+elimination::EliminationOptions buildElimOpts() {
+  auto Opts = lotus::dataflow_tool::parseEliminationOptions(ElimMethodOpt);
+  if (OrderingOpt == "cost-aware")
+    Opts.Ordering = elimination::OrderingPolicy::CostAware;
+  Opts.EnableEAN = EanOpt;
+  Opts.EnableGreedy = GreedyOpt;
+  Opts.EANLaws = (EanLawsOpt == "kleene")
+                     ? elimination::ean::LawProfile::kleeneAlgebra()
+                     : elimination::ean::LawProfile::safeMinimal();
+  Opts.EANCost = (EanCostOpt == "dag")
+                     ? elimination::ean::CostModel::dag()
+                     : elimination::ean::CostModel::uniform();
+  elimination::ean::Budget B = elimination::ean::Budget::unbounded();
+  if (EanRoundLimit)
+    B.roundLimit = EanRoundLimit;
+  if (EanNodeLimit)
+    B.nodeLimit = EanNodeLimit;
+  if (EanTimeLimit > 0.0)
+    B.timeLimitSec = EanTimeLimit;
+  Opts.EANBudget = B;
+  Opts.MeasurePeakNodes = MeasurePeakOpt;
+  Opts.EANMinNodes = EanMinNodes;
+  Opts.EANMonotone = EanMonotoneOpt;
+  Opts.InterpRepeat = InterpRepeat ? InterpRepeat : 1;
+  Opts.InterpMemo = MemoInterpOpt;
+  return Opts;
+}
+
+// Build PathSummaryEquationOptions (with the EAN sub-config) for the
+// interprocedural path-summary solver from the same evaluation CLI flags.
+elimination::PathSummaryEquationOptions buildInterSummaryOpts() {
+  elimination::PathSummaryEquationOptions Opts;
+  auto &E = Opts.EAN;
+  E.EnableEAN = EanOpt;
+  E.EnableGreedy = GreedyOpt;
+  E.EANLaws = (EanLawsOpt == "kleene")
+                  ? elimination::ean::LawProfile::kleeneAlgebra()
+                  : elimination::ean::LawProfile::safeMinimal();
+  E.EANCost = (EanCostOpt == "dag") ? elimination::ean::CostModel::dag()
+                                    : elimination::ean::CostModel::uniform();
+  elimination::ean::Budget B = elimination::ean::Budget::unbounded();
+  if (EanRoundLimit)
+    B.roundLimit = EanRoundLimit;
+  if (EanNodeLimit)
+    B.nodeLimit = EanNodeLimit;
+  if (EanTimeLimit > 0.0)
+    B.timeLimitSec = EanTimeLimit;
+  E.EANBudget = B;
+  E.EANMinNodes = EanMinNodes;
+  E.EANMonotone = EanMonotoneOpt;
+  E.InterpRepeat = InterpRepeat ? InterpRepeat : 1;
+  return Opts;
+}
 
 ValueIdMap buildModuleValueIdMap(Module &M) {
   ValueIdMap ValueToId;
@@ -408,7 +599,8 @@ void printSolveMetadata(raw_ostream &OS, const ResultT &Result) {
      << ", fallback=" << toString(Diag.fallback_reason)
      << ", adt_reason=" << toString(Diag.adt_rejection_reason)
      << ", star_iters=" << Diag.star_iterations_total
-     << ", max_star_hit=" << (Diag.max_star_hit ? "true" : "false") << "\n";
+     << ", max_star_hit=" << (Diag.max_star_hit ? "true" : "false")
+     << ", peak_nodes=" << Diag.peak_matrix_nodes << "\n";
 }
 
 template <unsigned K, typename FactT, typename TransferT, typename NodeT>
@@ -423,7 +615,7 @@ void printSolveMetadata(
 
 template <typename ResultT>
 void dumpProfile(raw_ostream &OS, const FunctionView &View,
-                 const ResultT &Result, std::chrono::microseconds Elapsed) {
+                 const ResultT &Result, const Timings &T) {
   const auto CFG = collectCFGStats(View.Function);
   OS << "  [cfg] args=" << CFG.Arguments << ", blocks=" << CFG.Blocks
      << ", insts=" << CFG.Instructions << ", edges=" << CFG.Edges
@@ -431,8 +623,31 @@ void dumpProfile(raw_ostream &OS, const FunctionView &View,
      << ", max_succs=" << CFG.MaxSuccessors << ", phis=" << CFG.PhiNodes
      << ", calls=" << CFG.Calls << ", returns=" << CFG.Returns
      << ", unreachable=" << CFG.Unreachable
-     << ", elapsed_us=" << Elapsed.count() << "\n";
+     << ", elapsed_us=" << T.end2end << "\n";
+  OS << "  [timing] gen_us=" << T.gen << ", norm_us=" << T.norm
+     << ", interp_us=" << T.interp << ", end2end_us=" << T.end2end
+     << ", runs=" << T.runs << "\n";
   printSolveMetadata(OS, Result);
+
+  // Unified DAG statistics over the whole summary batch (matches the synthetic
+  // evaluation's DagStats — the Table VI structural metrics). The transfer type
+  // is deduced from the result so clients with a non-Instruction* atom (e.g.
+  // NonNull's edge transfer) profile correctly.
+  using ResultTransferT = typename ResultT::transfer_t;
+  using BatchExprRef = typename elimination::PathExprFactory<ResultTransferT>::Ref;
+  std::vector<BatchExprRef> Batch;
+  Batch.reserve(View.OrderedInsts.size());
+  for (auto *I : View.OrderedInsts) {
+    auto E = Result.ExprTo(I);
+    if (E)
+      Batch.push_back(E);
+  }
+  const auto DS = elimination::ean::computeDagStats<ResultTransferT>(Batch);
+  OS << "  [dagstats] nodes=" << DS.uniqueNodes << ", edges=" << DS.uniqueEdges
+     << ", tree=" << DS.expandedTree << ", seq=" << DS.concats
+     << ", stars=" << DS.stars << ", unions=" << DS.unions
+     << ", atoms=" << DS.atoms << ", sharing=" << DS.sharing()
+     << ", roots=" << Batch.size() << "\n";
 
   size_t NodesWithExpr = 0;
   size_t MissingExpr = 0;
@@ -500,10 +715,10 @@ void dumpProfile(raw_ostream &OS, const FunctionView &View,
 
 template <typename ResultT, typename Printer>
 void dumpTimedResult(raw_ostream &OS, const FunctionView &View, ResultT &Result,
-                     std::chrono::microseconds Elapsed, Printer &&PrintState) {
+                     const Timings &T, Printer &&PrintState) {
   const bool HasOutput = StdoutOpt || !OutDir.empty();
   if (HasOutput && (DumpProfileOpt || DumpExprsOpt))
-    dumpProfile(OS, View, Result, Elapsed);
+    dumpProfile(OS, View, Result, T);
   if (ProfileOnlyOpt || !HasOutput)
     return;
   lotus::dataflow_tool::printInstructionStates(
@@ -514,11 +729,45 @@ template <typename Runner, typename Printer>
 void runTimedAnalysis(raw_ostream &OS, const FunctionView &View,
                       const elimination::EliminationOptions &ElimOpts,
                       Runner &&Run, Printer &&PrintState) {
+  for (unsigned W = 0; W < WarmupOpt; ++W) {
+    auto Warm = Run(View.Function, ElimOpts);
+    (void)Warm;
+  }
+  const unsigned R = std::max(1u, static_cast<unsigned>(RepeatOpt));
+  std::vector<std::uint64_t> Gen, Norm, Interp, End;
+  Gen.reserve(R);
+  Norm.reserve(R);
+  Interp.reserve(R);
+  End.reserve(R);
+
+  // The R-1 timing-only runs are constructed and discarded (DataFlowResultT is
+  // not assignable, so we never reassign — we construct fresh each run).
+  auto Sample = [&](const auto &Res, std::uint64_t Us) {
+    const auto &D = Res.solveDiagnostics();
+    Gen.push_back(D.gen_time_us);
+    Norm.push_back(D.norm_time_us);
+    Interp.push_back(D.interp_time_us);
+    End.push_back(Us);
+  };
+  for (unsigned I = 0; I + 1 < R; ++I) {
+    const auto Start = std::chrono::steady_clock::now();
+    auto Tmp = Run(View.Function, ElimOpts);
+    Sample(Tmp, static_cast<std::uint64_t>(
+                    std::chrono::duration_cast<std::chrono::microseconds>(
+                        std::chrono::steady_clock::now() - Start)
+                        .count()));
+  }
+  // Final measured run is kept for the structural dump.
   const auto Start = std::chrono::steady_clock::now();
   auto Result = Run(View.Function, ElimOpts);
-  const auto Elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
-      std::chrono::steady_clock::now() - Start);
-  dumpTimedResult(OS, View, Result, Elapsed, std::forward<Printer>(PrintState));
+  Sample(Result, static_cast<std::uint64_t>(
+                     std::chrono::duration_cast<std::chrono::microseconds>(
+                         std::chrono::steady_clock::now() - Start)
+                         .count()));
+
+  const Timings T{medianOf(Gen), medianOf(Norm), medianOf(Interp),
+                  medianOf(End), R};
+  dumpTimedResult(OS, View, Result, T, std::forward<Printer>(PrintState));
 }
 
 template <typename ResultT, typename Printer>
@@ -571,6 +820,116 @@ void runTimedInterproceduralAnalysis(raw_ostream &OS, Module &M,
                             [&](const auto &Key, const auto &Res) {
                               PrintState(Key, Res, ValueToId);
                             });
+}
+
+// Emit the path-summary solver's Table VI/VII diagnostics (equation graph, the
+// EAN/Greedy stage timings, and the batch structural stats before/after
+// optimization). Within one EAN/Greedy run, dagstats-before is the raw
+// (Default) batch and dagstats-after is the optimized one.
+template <unsigned K, typename FactT, typename TransferT, typename NodeT>
+void emitInterSummaryDiagnostics(
+    raw_ostream &OS,
+    const elimination::InterDataFlowResultT<K, FactT, TransferT, NodeT>
+        &Result) {
+  if (!Result.hasSummarySolveDiagnostics())
+    return;
+  const auto &D = Result.summarySolveDiagnostics();
+  OS << "  [inter-summary] contexts=" << D.discovered_context_node_count
+     << ", seeds=" << D.seed_count << ", eqn_nodes=" << D.equation_node_count
+     << ", eqn_edges=" << D.equation_edge_count << ", scc=" << D.scc_count
+     << ", cyclic_scc=" << D.cyclic_scc_count << ", gen_us=" << D.gen_time_us
+     << ", norm_us=" << D.norm_time_us << ", interp_us=" << D.interp_time_us
+     << "\n";
+  auto EmitStats = [&](const char *Tag, const elimination::ean::DagStats &S) {
+    OS << "  [" << Tag << "] nodes=" << S.uniqueNodes
+       << ", edges=" << S.uniqueEdges << ", tree=" << S.expandedTree
+       << ", seq=" << S.concats << ", stars=" << S.stars
+       << ", unions=" << S.unions << ", atoms=" << S.atoms
+       << ", sharing=" << S.sharing() << "\n";
+  };
+  EmitStats("dagstats-before", D.summary_before);
+  EmitStats("dagstats-after", D.summary_after);
+}
+
+// Run one interprocedural client through the path-summary solver (EAN/Greedy
+// applied to the summary batch) and emit timing + Table VI/VII diagnostics,
+// then the per-(inst,ctx) facts (for RQ1-inter differential).
+template <typename Runner, typename Printer>
+void runInterSummaryAnalysis(raw_ostream &OS, Module &M, Function &Entry,
+                             Runner &&Run, Printer &&PrintState) {
+  const auto Start = std::chrono::steady_clock::now();
+  auto Result = Run(Entry);
+  const auto Elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - Start);
+  const auto ValueToId = buildModuleValueIdMap(M);
+  OS << "  [profile] elapsed_us=" << Elapsed.count() << "\n";
+  printSolveMetadata(OS, Result);
+  emitInterSummaryDiagnostics(OS, Result);
+  dumpInterproceduralResult(OS, M, ValueToId, Result,
+                            [&](const auto &Key, const auto &Res) {
+                              PrintState(Key, Res, ValueToId);
+                            });
+}
+
+// Summary-solver variants of the interprocedural clients. reachable is clean
+// (Entry, ICF, Options); the others take LLVM analyses that we leave null (the
+// summary problem tolerates null AA/MSSA/AC/DT/TLI, degrading precision but not
+// crashing) — the driver records any client that fails to run.
+void runInterSummaryReachable(raw_ostream &OS, Module &M, Function &Entry) {
+  auto Opts = buildInterSummaryOpts();
+  runInterSummaryAnalysis(
+      OS, M, Entry,
+      [&](Function &F) {
+        return elimination::runInterSummaryElimReachable(&F, nullptr, Opts);
+      },
+      [&](const auto &Key, const auto &Result, const auto &) {
+        OS << (Result.IN(Key) ? "true" : "false");
+      });
+}
+
+void runInterSummaryReachingDefinitions(raw_ostream &OS, Module &M,
+                                        Function &Entry) {
+  auto Opts = buildInterSummaryOpts();
+  runInterSummaryAnalysis(
+      OS, M, Entry,
+      [&](Function &F) {
+        return elimination::runInterSummaryElimReachingDefinitions(
+            &F, nullptr, nullptr, nullptr, Opts);
+      },
+      [&](const auto &Key, const auto &Result, const auto &ValueToId) {
+        lotus::dataflow_tool::formatValueSet(OS, Result.IN(Key), ValueToId);
+      });
+}
+
+void runInterSummaryUninitialized(raw_ostream &OS, Module &M, Function &Entry) {
+  auto Opts = buildInterSummaryOpts();
+  runInterSummaryAnalysis(
+      OS, M, Entry,
+      [&](Function &F) {
+        return elimination::runInterSummaryElimUninitVariables(
+            &F, nullptr, nullptr, nullptr, nullptr, Opts);
+      },
+      [&](const auto &Key, const auto &Result, const auto &ValueToId) {
+        lotus::dataflow_tool::formatValueSet(OS, Result.IN(Key), ValueToId);
+      });
+}
+
+void runInterSummaryConstantPropagation(raw_ostream &OS, Module &M,
+                                        Function &Entry) {
+  auto Opts = buildInterSummaryOpts();
+  runInterSummaryAnalysis(
+      OS, M, Entry,
+      [&](Function &F) {
+        return elimination::runInterSummaryElimConstantPropagation(
+            &F, nullptr, nullptr, nullptr, nullptr, nullptr, Opts);
+      },
+      [&](const auto &Key, const auto &Result, const auto &ValueToId) {
+        lotus::dataflow_tool::formatValueMap(
+            OS, Result.IN(Key), ValueToId,
+            [&](const elimination::ConstantPropagationValue &Value) {
+              return formatValueLatticeElement(Value);
+            });
+      });
 }
 
 template <typename Runner>
@@ -627,10 +986,17 @@ void runBoolInterAnalysis(raw_ostream &OS, Module &M, Function &Entry,
 
 void runReachingDefinitions(raw_ostream &OS, const FunctionView &View,
                             const elimination::EliminationOptions &ElimOpts) {
+  const bool TranslApa = (InterpOpt == "translapa");
+  OS << "  [interp] mode=" << (TranslApa ? "translapa" : "generic") << "\n";
   runSetIntraAnalysis(
       OS, View, ElimOpts,
-      [](Function &F, const elimination::EliminationOptions &Opts) {
-        return elimination::runIntraElimReachingDefinitions(&F, nullptr, Opts);
+      [TranslApa](Function &F, const elimination::EliminationOptions &Opts) {
+        return TranslApa
+                   ? elimination::runIntraTranslApaReachingDefinitions(&F,
+                                                                       nullptr,
+                                                                       Opts)
+                   : elimination::runIntraElimReachingDefinitions(&F, nullptr,
+                                                                  Opts);
       });
 }
 
@@ -641,6 +1007,55 @@ void runUninitialized(raw_ostream &OS, const FunctionView &View,
       [](Function &F, const elimination::EliminationOptions &Opts) {
         return elimination::runIntraElimUninitVariables(&F, nullptr, Opts);
       });
+}
+
+// Canonical, vocabulary-free serialization of an affine relation: the Howell
+// normal form's rows are already canonical, so equal relations serialize
+// identically. This lets the RQ1 differential compare Default vs EAN(safe/kleene)
+// affine facts as text WITHOUT needing the (already-freed) per-function
+// vocabulary at print time.
+std::string serializeAffine(const elimination::AffineRelation &R) {
+  if (R.bottom)
+    return "bottom";
+  std::string Buf;
+  raw_string_ostream OS(Buf);
+  bool FirstComp = true;
+  for (const auto &Entry : R.components) {
+    if (!FirstComp)
+      OS << "|";
+    FirstComp = false;
+    OS << "w" << Entry.first << ":";
+    std::vector<std::string> Rows;
+    Rows.reserve(Entry.second.constraints.size());
+    for (const auto &Row : Entry.second.constraints) {
+      std::string RowStr;
+      for (std::size_t i = 0; i < Row.size(); ++i) {
+        if (i)
+          RowStr += ",";
+        RowStr += std::to_string(Row[i].getZExtValue());
+      }
+      Rows.push_back(std::move(RowStr));
+    }
+    std::sort(Rows.begin(), Rows.end()); // guard against row-order nondeterminism
+    bool FirstRow = true;
+    for (auto &Row : Rows) {
+      if (!FirstRow)
+        OS << ";";
+      FirstRow = false;
+      OS << Row;
+    }
+  }
+  return OS.str();
+}
+
+void runAffine(raw_ostream &OS, const FunctionView &View,
+               const elimination::EliminationOptions &ElimOpts) {
+  runTimedAnalysis(
+      OS, View, ElimOpts,
+      [](Function &F, const elimination::EliminationOptions &Opts) {
+        return elimination::runIntraElimAffine(&F, Opts);
+      },
+      [&](Instruction *I, auto &Result) { OS << serializeAffine(Result.IN(I)); });
 }
 
 void runConstantPropagation(raw_ostream &OS, const FunctionView &View,
@@ -714,26 +1129,41 @@ void runSign(raw_ostream &OS, const FunctionView &View,
 
 void runReachable(raw_ostream &OS, const FunctionView &View,
                   const elimination::EliminationOptions &ElimOpts) {
+  const bool TranslApa = (InterpOpt == "translapa");
+  OS << "  [interp] mode=" << (TranslApa ? "translapa" : "generic") << "\n";
   runBoolIntraAnalysis(
       OS, View, ElimOpts,
-      [](Function &F, const elimination::EliminationOptions &Opts) {
-        return elimination::runIntraElimReachable(&F, Opts);
+      [TranslApa](Function &F, const elimination::EliminationOptions &Opts) {
+        return TranslApa ? elimination::runIntraTranslApaReachable(&F, Opts)
+                         : elimination::runIntraElimReachable(&F, Opts);
       });
 }
 
 void runInterReachingDefinitions(raw_ostream &OS, Module &M, Function &Entry) {
+  if (InterSummaryOpt) {
+    runInterSummaryReachingDefinitions(OS, M, Entry);
+    return;
+  }
   runSetInterAnalysis(OS, M, Entry, [](Function &F) {
     return elimination::runInterElimReachingDefinitions(&F);
   });
 }
 
 void runInterUninitialized(raw_ostream &OS, Module &M, Function &Entry) {
+  if (InterSummaryOpt) {
+    runInterSummaryUninitialized(OS, M, Entry);
+    return;
+  }
   runSetInterAnalysis(OS, M, Entry, [](Function &F) {
     return elimination::runInterElimUninitVariables(&F);
   });
 }
 
 void runInterConstantPropagation(raw_ostream &OS, Module &M, Function &Entry) {
+  if (InterSummaryOpt) {
+    runInterSummaryConstantPropagation(OS, M, Entry);
+    return;
+  }
   runMapInterAnalysis(
       OS, M, Entry,
       [](Function &F) {
@@ -745,6 +1175,22 @@ void runInterConstantPropagation(raw_ostream &OS, Module &M, Function &Entry) {
 }
 
 void runInterReachable(raw_ostream &OS, Module &M, Function &Entry) {
+  if (ModularInterOpt) {
+    auto Opts = buildInterSummaryOpts();
+    runInterSummaryAnalysis(
+        OS, M, Entry,
+        [&](Function &F) {
+          return elimination::runModularInterReachable(&F, nullptr, Opts);
+        },
+        [&](const auto &Key, const auto &Result, const auto &) {
+          OS << (Result.IN(Key) ? "true" : "false");
+        });
+    return;
+  }
+  if (InterSummaryOpt) {
+    runInterSummaryReachable(OS, M, Entry);
+    return;
+  }
   runBoolInterAnalysis(OS, M, Entry, [](Function &F) {
     return elimination::runInterElimReachable(&F);
   });
@@ -817,31 +1263,69 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  const auto *Handler =
-      lotus::dataflow_tool::findHandler(AnalysisOpt, Handlers);
-  if (!Handler) {
-    errs() << "error: unknown elimination analysis '" << AnalysisOpt << "'\n";
+  // Parse a comma-separated client list (amortizes module loading across
+  // clients in one process).
+  std::vector<const AnalysisHandler *> Clients;
+  {
+    std::stringstream SS(AnalysisOpt);
+    std::string Name;
+    while (std::getline(SS, Name, ',')) {
+      if (Name.empty())
+        continue;
+      const auto *H = lotus::dataflow_tool::findHandler(StringRef(Name), Handlers);
+      if (!H) {
+        errs() << "error: unknown elimination analysis '" << Name << "'\n";
+        return 1;
+      }
+      Clients.push_back(H);
+    }
+  }
+  if (Clients.empty()) {
+    errs() << "error: no analysis selected\n";
     return 1;
   }
 
-  const auto ElimOpts =
-      lotus::dataflow_tool::parseEliminationOptions(ElimMethodOpt);
-  OS << "[elim:" << AnalysisOpt << "]\n";
+  const auto ElimOpts = buildElimOpts();
+  OS << "[elim] clients=" << AnalysisOpt << ", method=" << ElimMethodOpt
+     << ", ordering=" << OrderingOpt << ", ean=" << (EanOpt ? "on" : "off")
+     << ", ean_laws=" << EanLawsOpt << ", repeat=" << RepeatOpt
+     << ", ean_min_nodes=" << EanMinNodes << ", interp_repeat=" << InterpRepeat
+     << ", max_func_insts=" << MaxFuncInsts << "\n";
 
-  if (Handler->ModuleScoped) {
+  const bool AnyModule =
+      std::any_of(Clients.begin(), Clients.end(),
+                  [](const AnalysisHandler *H) { return H->ModuleScoped; });
+  if (AnyModule) {
+    if (Clients.size() != 1) {
+      errs() << "error: module-scoped analyses must be run one at a time\n";
+      return 1;
+    }
     Function *Entry = M->getFunction(EntryFunctionOpt);
     if (Entry == nullptr || Entry->isDeclaration()) {
       errs() << "error: entry function '" << EntryFunctionOpt
              << "' not found or is a declaration\n";
       return 1;
     }
-    Handler->RunModule(OS, *M, *Entry);
+    Clients.front()->RunModule(OS, *M, *Entry);
   } else {
+    std::size_t Skipped = 0;
     lotus::dataflow_tool::forEachDefinedFunction(
         *M, OS, [&](const FunctionView &View) {
-          Handler->RunFunction(OS, View, ElimOpts);
+          if (MaxFuncInsts != 0 &&
+              View.OrderedInsts.size() > MaxFuncInsts) {
+            OS << "  [skipped] reason=too_large insts="
+               << View.OrderedInsts.size() << "\n";
+            ++Skipped;
+            return;
+          }
+          for (const AnalysisHandler *H : Clients) {
+            OS << "  [client:" << H->Name << "]\n";
+            H->RunFunction(OS, View, ElimOpts);
+          }
         });
+    OS << "[summary] skipped_functions=" << Skipped << "\n";
   }
 
+  OS << "[mem] peak_rss_kb=" << peakRssKb() << "\n";
   return 0;
 }


### PR DESCRIPTION
This PR adds three interrelated path-expression contributions to the APA (Algebraic Program Analysis) engine, built on top of the current core, plus an intraprocedural scalability fix. It is based directly on upstream/main and touches only APA engine code, tools, and unit tests (74 files; no docs, evaluation artifacts, or editor config).

What's included

1. EAN — equality-saturation path-expression optimizer

include/Dataflow/APA/EAN/*

An optional optimization stage inserted between path-expression construction and interpretation. It treats each per-node path-expression DAG as optimizable IR: imports it into a law-parametric e-graph, applies guarded rewrites (ACI canonicalization, prefix/suffix factorization, star rules, guarded expansion) under a resource budget, and re-extracts a reuse-aware, cost-minimized form back into the expression factory.

- Semantics are preserved relative to the client's declared law profile (e.g. left/right distributivity, annihilation, Kleene star); the default safe-minimal profile is universally sound.
- On any resource failure the pass falls back to the original batch (root preservation), so it is never worse than the baseline.
- Wired into the intraprocedural solver via EliminationOptions (--ean / --greedy in lotus-dfa-apa).

2. TranslAPA baseline

include/Dataflow/APA/Baseline/TranslAPA/*

A mechanical Gen/Kill semiring interpreter (closed-form star, no fixpoint iteration) that reuses the same elimination front-end and only swaps the interpreter. Serves as an external comparison point for the path-expression pipeline. Exposed via --interp=translapa.

3. E6 — modular interprocedural solver

include/Dataflow/APA/Solver/ModularInterSummary{Solver,Driver,Interpreter}.h, CallGraphSCC.h

Builds one entry→exit summary per procedure over that procedure's own CFG, replacing each call site with a symbolic summary-call atom instead of inlining the callee. Summaries are solved in reverse-topological call-graph order; recursion is closed by a bounded fixpoint at interpretation time. This is context-insensitive (functional), avoiding the whole-program × context product that makes the monolithic summary solver blow up.

- Exposed via --modular-inter in lotus-dfa-apa (--analysis=inter_reachable).
- Validated against the whole-program summary solver as an oracle: on every coreutils subject where the oracle terminates, per-instruction reachability facts match exactly.

4. Sparse intraprocedural elimination

include/Dataflow/APA/Solver/PathSummaryEquationSolver.h

Large cyclic SCCs (above a size threshold) are solved with sparse min-fill Gaussian elimination instead of the dense O(N³) Floyd–Warshall closure. It exploits the sparsity of control-flow SCCs and is value-equivalent to the dense form; small SCCs keep the dense path. This lets procedures with large cyclic control-flow regions complete instead of timing out.

Tests

Unit tests under tests/unit/Dataflow/APA/: EAN/*, ModularInterSummary{Solver,Driver}Test, CallGraphSCCTest, PathSummaryEquationSolverTest (including a large-cyclic-SCC language-equivalence check for the sparse path), and Baseline/TranslAPA*.
